### PR TITLE
feat(selector): unified multi-tool line abstraction with auto speed-test selection

### DIFF
--- a/backend/service/selector/selector.go
+++ b/backend/service/selector/selector.go
@@ -63,9 +63,27 @@ type Prober interface {
 type TCPProber struct {
 	// Timeout 单条线路探测总超时（默认 3s）。
 	Timeout time.Duration
-	// InsecureTLS 探测 https 探测地址时跳过证书校验（穿透入口多为 IP 直连，
-	// 证书校验会误判可用性）。
-	InsecureTLS bool
+	// VerifyTLS 为 true 时校验证书；默认 false 跳过证书校验——穿透入口
+	// 常是 IP:PORT 直连，证书与 SNI 均不可信，探测只关心可达性。
+	VerifyTLS bool
+
+	// once/transport 复用同一个 http.Transport，避免每次探测都新建
+	// 连接池（高频探测时开销显著）。
+	once      sync.Once
+	transport *http.Transport
+}
+
+// transportFor 惰性初始化并复用 Transport（并发安全，http.Transport
+// 内部自带连接池与并发保护）。
+func (p *TCPProber) transportFor() *http.Transport {
+	p.once.Do(func() {
+		p.transport = &http.Transport{
+			// 穿透入口常是 IP:PORT 直连，证书与 SNI 均不可信；仅探测可达性，
+			// 默认跳过证书校验（VerifyTLS 为 true 时校验证书）。
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !p.VerifyTLS},
+		}
+	})
+	return p.transport
 }
 
 // Probe 并发安全，单次调用阻塞至探测完成。
@@ -91,13 +109,7 @@ func (p *TCPProber) Probe(ctx context.Context, line Line) ProbeResult {
 	}
 
 	httpStart := time.Now()
-	client := &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			// 穿透入口常是 IP:PORT 直连，证书与 SNI 均不可信；仅探测可达性。
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: p.InsecureTLS},
-		},
-	}
+	client := &http.Client{Timeout: timeout, Transport: p.transportFor()}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, line.ProbeURL, nil)
 	if err != nil {
 		res.Err = &ProbeError{Reason: err.Error()}
@@ -136,6 +148,9 @@ type Selector struct {
 	prober Prober
 	// tolerance 延迟差在此范围内不切换（防抖）。
 	tolerance time.Duration
+	// maxConcurrent 单轮探测的最大并发数（信号量限流，避免线路过多时
+	// 同时打爆对端/本机连接）。
+	maxConcurrent int
 	// lines 当前线路（按添加顺序）。
 	lines []Line
 	// results 最近一次测速结果（lineID -> result）。
@@ -147,7 +162,8 @@ type Selector struct {
 	current string
 }
 
-// NewSelector 创建选择器。tolerance<=0 时取默认 50ms。
+// NewSelector 创建选择器。tolerance<=0 时取默认 50ms；maxConcurrent<=0 时
+// 取默认 8。
 func NewSelector(prober Prober, tolerance time.Duration) *Selector {
 	if prober == nil {
 		prober = &TCPProber{}
@@ -156,17 +172,30 @@ func NewSelector(prober Prober, tolerance time.Duration) *Selector {
 		tolerance = 50 * time.Millisecond
 	}
 	return &Selector{
-		prober:    prober,
-		tolerance: tolerance,
-		results:   make(map[string]ProbeResult),
+		prober:        prober,
+		tolerance:     tolerance,
+		maxConcurrent: 8,
+		results:       make(map[string]ProbeResult),
 	}
 }
 
+// SetMaxConcurrent 设置单轮探测的最大并发数（须在首次 ProbeAll 前调用，
+// 否则不保证生效）。<=0 时重置为默认 8。
+func (s *Selector) SetMaxConcurrent(n int) {
+	if n <= 0 {
+		n = 8
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.maxConcurrent = n
+}
+
 // SetLines 全量替换线路集合（保留锁线与当前选择；失效的锁线自动解除）。
+// 拷贝传入 slice，避免调用方后续修改污染内部状态。
 func (s *Selector) SetLines(lines []Line) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.lines = lines
+	s.lines = append([]Line(nil), lines...)
 	known := make(map[string]bool, len(lines))
 	for _, l := range lines {
 		known[l.ID] = true
@@ -192,15 +221,19 @@ func (s *Selector) Lines() []Line {
 }
 
 // ProbeAll 并发探测全部线路并刷新结果，返回按线路 id 索引的结果。
+// 并发数受 maxConcurrent 信号量限制，线路过多时不会同时打爆对端/本机连接。
 func (s *Selector) ProbeAll(ctx context.Context) map[string]ProbeResult {
 	s.mu.Lock()
 	lines := append([]Line(nil), s.lines...)
+	maxConcurrent := s.maxConcurrent
 	s.mu.Unlock()
 
 	if len(lines) == 0 {
 		return map[string]ProbeResult{}
 	}
 
+	// 信号量限流：最多 maxConcurrent 个探测并发执行。
+	sem := make(chan struct{}, maxConcurrent)
 	results := make(map[string]ProbeResult, len(lines))
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -208,6 +241,15 @@ func (s *Selector) ProbeAll(ctx context.Context) map[string]ProbeResult {
 		wg.Add(1)
 		go func(l Line) {
 			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				mu.Lock()
+				results[l.ID] = ProbeResult{LineID: l.ID, Err: &ProbeError{Reason: "probe canceled"}}
+				mu.Unlock()
+				return
+			}
 			r := s.prober.Probe(ctx, l)
 			mu.Lock()
 			results[l.ID] = r
@@ -222,6 +264,15 @@ func (s *Selector) ProbeAll(ctx context.Context) map[string]ProbeResult {
 	return results
 }
 
+// effectiveLatency 返回用于选线的延迟：配置了 ProbeURL 且 HTTP 探测成功时
+// 以 HTTP 延迟为准（它反映真实的出网可用性），否则回退到 TCP 握手延迟。
+func effectiveLatency(r ProbeResult) time.Duration {
+	if r.HTTPLatency > 0 {
+		return r.HTTPLatency
+	}
+	return r.TCPLatency
+}
+
 // Select 根据最新结果选线：锁线优先；否则取最快可用线路，且与当前线路的
 // 延迟差超过 tolerance 才切换（防抖）。
 func (s *Selector) Select() Selection {
@@ -231,7 +282,7 @@ func (s *Selector) Select() Selection {
 	if s.lockedLine != "" {
 		if r, ok := s.results[s.lockedLine]; ok && r.Err == nil {
 			s.current = s.lockedLine
-			return Selection{LineID: s.lockedLine, Locked: true, Latency: r.TCPLatency}
+			return Selection{LineID: s.lockedLine, Locked: true, Latency: effectiveLatency(r)}
 		}
 		// 锁定的线路失效：解除锁，退回自动模式。
 		s.lockedLine = ""
@@ -248,15 +299,17 @@ func (s *Selector) Select() Selection {
 	if s.current != "" {
 		cur, curOK := s.results[s.current]
 		bestR, bestOK := s.results[best]
-		if curOK && bestOK && cur.Err == nil && cur.TCPLatency-bestR.TCPLatency <= s.tolerance {
-			return Selection{LineID: s.current, Latency: cur.TCPLatency}
+		if curOK && bestOK && cur.Err == nil && effectiveLatency(cur)-effectiveLatency(bestR) <= s.tolerance {
+			return Selection{LineID: s.current, Latency: effectiveLatency(cur)}
 		}
 	}
 	s.current = best
-	return Selection{LineID: best, Latency: s.results[best].TCPLatency}
+	return Selection{LineID: best, Latency: effectiveLatency(s.results[best])}
 }
 
-// bestUsable 返回可用线路中 TCP 延迟最小的一条；无可用时返回空串。
+// bestUsable 返回可用线路中延迟最小的一条；无可用时返回空串。
+// 排序键为 effectiveLatency：配置了 ProbeURL 时优先按 HTTP 出网延迟，
+// 否则按 TCP 握手延迟。
 func (s *Selector) bestUsable() string {
 	type cand struct {
 		id  string
@@ -267,7 +320,7 @@ func (s *Selector) bestUsable() string {
 		if r.Err != nil {
 			continue
 		}
-		cands = append(cands, cand{id: id, lat: r.TCPLatency})
+		cands = append(cands, cand{id: id, lat: effectiveLatency(r)})
 	}
 	if len(cands) == 0 {
 		return ""
@@ -336,8 +389,9 @@ func (s *Selector) Run(ctx context.Context, interval time.Duration) {
 			return
 		case <-ticker.C:
 			s.ProbeAll(ctx)
-			s.Select()
-			log.Printf("[selector] current line: %q", s.current)
+			sel := s.Select()
+			// 用返回值而非直接读 s.current（后者在锁外，会与并发调用产生数据竞争）。
+			log.Printf("[selector] current line: %q", sel.LineID)
 		}
 	}
 }

--- a/backend/service/selector/selector.go
+++ b/backend/service/selector/selector.go
@@ -1,0 +1,343 @@
+// Package selector 实现「多工具穿透线路统一抽象 + 自动测速选线」。
+//
+// NetPanel 内置 frp / nps / easytier / wireguard 等多个穿透工具，各自维护
+// 自己的 Manager。本包提供线路层的公共抽象：任何工具只要把它的可用线路
+// 描述为 []Line（地址 + 可选 HTTP 204 探测地址），就能接入统一的
+// 并发测速、自动选线（容差防抖）、手动锁线与后台守护。
+//
+// 选线语义参考 Clash 的 url-test：按延迟排序取最快，tolerance 内不切换
+// 避免抖动；锁线时完全跳过自动切换。
+package selector
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Line 一条可选的穿透线路（多工具适配的统一描述）。
+type Line struct {
+	// ID 线路唯一标识（如 "frp:1" / "nps:2"）。
+	ID string
+	// Name 展示名（如 "阿里云 frps"）。
+	Name string
+	// Tool 来源工具（"frp" / "nps" / "easytier" / "wireguard" ...）。
+	Tool string
+	// Address 探测地址（host:port）。做 TCP 握手延迟测量。
+	Address string
+	// ProbeURL 可选。非空时额外做一次 HTTP 204 探测（用于区分「能连上」与
+	// 「能正常出网」）。
+	ProbeURL string
+}
+
+// ProbeResult 单条线路的一次测速结果。
+type ProbeResult struct {
+	LineID string
+	// TCPLatency TCP 握手延迟。
+	TCPLatency time.Duration
+	// HTTPLatency HTTP 204 探测延迟；未配置 ProbeURL 时为 0。
+	HTTPLatency time.Duration
+	// Err 非空表示该线路本次不可用（超时/拒绝/握手失败）。
+	Err error
+}
+
+// ProbeError 标记线路不可用，带人类可读原因。
+type ProbeError struct {
+	Reason string
+}
+
+func (e *ProbeError) Error() string { return e.Reason }
+
+// Prober 单条线路的探测器。测试可注入假实现，避免真实网络依赖。
+type Prober interface {
+	Probe(ctx context.Context, line Line) ProbeResult
+}
+
+// TCPProber 默认实现：TCP 握手 + 可选 HTTP 204 探测。
+type TCPProber struct {
+	// Timeout 单条线路探测总超时（默认 3s）。
+	Timeout time.Duration
+	// InsecureTLS 探测 https 探测地址时跳过证书校验（穿透入口多为 IP 直连，
+	// 证书校验会误判可用性）。
+	InsecureTLS bool
+}
+
+// Probe 并发安全，单次调用阻塞至探测完成。
+func (p *TCPProber) Probe(ctx context.Context, line Line) ProbeResult {
+	timeout := p.Timeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", line.Address)
+	if err != nil {
+		return ProbeResult{LineID: line.ID, Err: &ProbeError{Reason: err.Error()}}
+	}
+	tcpLatency := time.Since(start)
+	_ = conn.Close()
+
+	res := ProbeResult{LineID: line.ID, TCPLatency: tcpLatency}
+	if line.ProbeURL == "" {
+		return res
+	}
+
+	httpStart := time.Now()
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// 穿透入口常是 IP:PORT 直连，证书与 SNI 均不可信；仅探测可达性。
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: p.InsecureTLS},
+		},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, line.ProbeURL, nil)
+	if err != nil {
+		res.Err = &ProbeError{Reason: err.Error()}
+		return res
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		res.Err = &ProbeError{Reason: err.Error()}
+		return res
+	}
+	defer resp.Body.Close()
+	// 204 是约定探测响应；部分实现返回 200 也视为可达（放宽容错）。
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		res.Err = &ProbeError{Reason: "probe url returned " + resp.Status}
+		return res
+	}
+	res.HTTPLatency = time.Since(httpStart)
+	return res
+}
+
+// Selection 一次选线结果。
+type Selection struct {
+	// LineID 当前应使用的线路；无可用线路时为空串。
+	LineID string
+	// Locked 是否处于手动锁线状态。
+	Locked bool
+	// Latency 当前线路最近一次测得的 TCP 延迟。
+	Latency time.Duration
+}
+
+// Selector 持有线路集合与选线状态，负责并发测速与自动/手动选线。
+type Selector struct {
+	mu sync.Mutex
+
+	prober Prober
+	// tolerance 延迟差在此范围内不切换（防抖）。
+	tolerance time.Duration
+	// lines 当前线路（按添加顺序）。
+	lines []Line
+	// results 最近一次测速结果（lineID -> result）。
+	results map[string]ProbeResult
+
+	// lockedLine 手动锁定的线路；空串表示自动模式。
+	lockedLine string
+	// current 当前生效线路 id。
+	current string
+}
+
+// NewSelector 创建选择器。tolerance<=0 时取默认 50ms。
+func NewSelector(prober Prober, tolerance time.Duration) *Selector {
+	if prober == nil {
+		prober = &TCPProber{}
+	}
+	if tolerance <= 0 {
+		tolerance = 50 * time.Millisecond
+	}
+	return &Selector{
+		prober:    prober,
+		tolerance: tolerance,
+		results:   make(map[string]ProbeResult),
+	}
+}
+
+// SetLines 全量替换线路集合（保留锁线与当前选择；失效的锁线自动解除）。
+func (s *Selector) SetLines(lines []Line) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lines = lines
+	known := make(map[string]bool, len(lines))
+	for _, l := range lines {
+		known[l.ID] = true
+	}
+	for id := range s.results {
+		if !known[id] {
+			delete(s.results, id)
+		}
+	}
+	if s.lockedLine != "" && !known[s.lockedLine] {
+		s.lockedLine = ""
+	}
+	if s.current != "" && !known[s.current] {
+		s.current = ""
+	}
+}
+
+// Lines 返回当前线路列表（拷贝）。
+func (s *Selector) Lines() []Line {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Line(nil), s.lines...)
+}
+
+// ProbeAll 并发探测全部线路并刷新结果，返回按线路 id 索引的结果。
+func (s *Selector) ProbeAll(ctx context.Context) map[string]ProbeResult {
+	s.mu.Lock()
+	lines := append([]Line(nil), s.lines...)
+	s.mu.Unlock()
+
+	if len(lines) == 0 {
+		return map[string]ProbeResult{}
+	}
+
+	results := make(map[string]ProbeResult, len(lines))
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for _, line := range lines {
+		wg.Add(1)
+		go func(l Line) {
+			defer wg.Done()
+			r := s.prober.Probe(ctx, l)
+			mu.Lock()
+			results[l.ID] = r
+			mu.Unlock()
+		}(line)
+	}
+	wg.Wait()
+
+	s.mu.Lock()
+	s.results = results
+	s.mu.Unlock()
+	return results
+}
+
+// Select 根据最新结果选线：锁线优先；否则取最快可用线路，且与当前线路的
+// 延迟差超过 tolerance 才切换（防抖）。
+func (s *Selector) Select() Selection {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.lockedLine != "" {
+		if r, ok := s.results[s.lockedLine]; ok && r.Err == nil {
+			s.current = s.lockedLine
+			return Selection{LineID: s.lockedLine, Locked: true, Latency: r.TCPLatency}
+		}
+		// 锁定的线路失效：解除锁，退回自动模式。
+		s.lockedLine = ""
+	}
+
+	best := s.bestUsable()
+	if best == "" {
+		s.current = ""
+		return Selection{Locked: false}
+	}
+
+	// 防抖：当前线路仍可用，且不比最优慢超过 tolerance 时保持现状；
+	// 只有当当前线路比最优慢得更多（或更慢）才切换，避免频繁抖动。
+	if s.current != "" {
+		cur, curOK := s.results[s.current]
+		bestR, bestOK := s.results[best]
+		if curOK && bestOK && cur.Err == nil && cur.TCPLatency-bestR.TCPLatency <= s.tolerance {
+			return Selection{LineID: s.current, Latency: cur.TCPLatency}
+		}
+	}
+	s.current = best
+	return Selection{LineID: best, Latency: s.results[best].TCPLatency}
+}
+
+// bestUsable 返回可用线路中 TCP 延迟最小的一条；无可用时返回空串。
+func (s *Selector) bestUsable() string {
+	type cand struct {
+		id  string
+		lat time.Duration
+	}
+	var cands []cand
+	for id, r := range s.results {
+		if r.Err != nil {
+			continue
+		}
+		cands = append(cands, cand{id: id, lat: r.TCPLatency})
+	}
+	if len(cands) == 0 {
+		return ""
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].lat < cands[j].lat })
+	return cands[0].id
+}
+
+// Lock 手动锁定某条线路（必须存在于当前线路集合中，否则忽略）。
+func (s *Selector) Lock(lineID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, l := range s.lines {
+		if l.ID == lineID {
+			s.lockedLine = lineID
+			s.current = lineID
+			return
+		}
+	}
+}
+
+// Unlock 解除手动锁线，回到自动模式。清空 current，使下一次 Select
+// 立即按最新测速结果选择最优线路，而不是留在被锁的那条上。
+func (s *Selector) Unlock() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lockedLine = ""
+	s.current = ""
+}
+
+// State 返回当前完整状态（供 API/UI 展示）。
+type State struct {
+	Lines   []Line
+	Results map[string]ProbeResult
+	Current string
+	Locked  string
+}
+
+// Snapshot 返回当前状态（拷贝，线程安全）。
+func (s *Selector) Snapshot() State {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	results := make(map[string]ProbeResult, len(s.results))
+	for k, v := range s.results {
+		results[k] = v
+	}
+	return State{
+		Lines:   append([]Line(nil), s.lines...),
+		Results: results,
+		Current: s.current,
+		Locked:  s.lockedLine,
+	}
+}
+
+// Run 后台守护：按 interval 周期探测并自动选线，直到 ctx 取消。
+// 探测并发进行，单轮最坏耗时约等于探测超时；不会阻塞调用方。
+func (s *Selector) Run(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.ProbeAll(ctx)
+			s.Select()
+			log.Printf("[selector] current line: %q", s.current)
+		}
+	}
+}

--- a/backend/service/selector/selector.go
+++ b/backend/service/selector/selector.go
@@ -156,6 +156,14 @@ type Selector struct {
 	// results 最近一次测速结果（lineID -> result）。
 	results map[string]ProbeResult
 
+	// failureThreshold 连续失败多少次后线路才判为不可用（默认 1：任何一次
+	// 失败都立即视为不可用；调大可容忍瞬时抖动，避免频繁切线）。
+	failureThreshold int
+	// failStreak 每条线路的连续失败次数（成功探测时清零）。
+	failStreak map[string]int
+	// lastGood 每条线路最近一次成功探测的结果（失败未达阈值时兜底选线）。
+	lastGood map[string]ProbeResult
+
 	// lockedLine 手动锁定的线路；空串表示自动模式。
 	lockedLine string
 	// current 当前生效线路 id。
@@ -172,10 +180,13 @@ func NewSelector(prober Prober, tolerance time.Duration) *Selector {
 		tolerance = 50 * time.Millisecond
 	}
 	return &Selector{
-		prober:        prober,
-		tolerance:     tolerance,
-		maxConcurrent: 8,
-		results:       make(map[string]ProbeResult),
+		prober:           prober,
+		tolerance:        tolerance,
+		maxConcurrent:    8,
+		failureThreshold: 1,
+		results:          make(map[string]ProbeResult),
+		failStreak:       make(map[string]int),
+		lastGood:         make(map[string]ProbeResult),
 	}
 }
 
@@ -188,6 +199,18 @@ func (s *Selector) SetMaxConcurrent(n int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.maxConcurrent = n
+}
+
+// SetFailureThreshold 设置线路判为不可用所需的连续失败次数（须在首次
+// ProbeAll 前调用，否则不保证生效）。默认 1（任何一次失败立即判不可用）；
+// 调大可容忍瞬时抖动，例如 2 表示连续两次探测失败才切换线路。
+func (s *Selector) SetFailureThreshold(n int) {
+	if n <= 0 {
+		n = 1
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failureThreshold = n
 }
 
 // SetLines 全量替换线路集合（保留锁线与当前选择；失效的锁线自动解除）。
@@ -203,6 +226,12 @@ func (s *Selector) SetLines(lines []Line) {
 	for id := range s.results {
 		if !known[id] {
 			delete(s.results, id)
+		}
+	}
+	for id := range s.failStreak {
+		if !known[id] {
+			delete(s.failStreak, id)
+			delete(s.lastGood, id)
 		}
 	}
 	if s.lockedLine != "" && !known[s.lockedLine] {
@@ -260,6 +289,15 @@ func (s *Selector) ProbeAll(ctx context.Context) map[string]ProbeResult {
 
 	s.mu.Lock()
 	s.results = results
+	// 更新连续失败计数与最近成功结果：成功清零，失败累加（供阈值判可用）。
+	for id, r := range results {
+		if r.Err != nil {
+			s.failStreak[id]++
+		} else {
+			s.failStreak[id] = 0
+			s.lastGood[id] = r
+		}
+	}
 	s.mu.Unlock()
 	return results
 }
@@ -273,6 +311,30 @@ func effectiveLatency(r ProbeResult) time.Duration {
 	return r.TCPLatency
 }
 
+// usable 判断线路当前是否可用：最近一次探测成功；或失败但连续失败次数未达
+// 阈值（此时用最近成功结果兜底选线）。无任何成功记录的线路始终视为不可用。
+func (s *Selector) usable(r ProbeResult) bool {
+	if r.Err == nil {
+		return true
+	}
+	if s.failStreak[r.LineID] >= s.failureThreshold {
+		return false
+	}
+	_, ok := s.lastGood[r.LineID]
+	return ok
+}
+
+// latencyFor 返回线路参与排序的延迟：失败但未达阈值时用最近成功结果兜底，
+// 避免瞬时抖动把延迟抬到异常高。
+func (s *Selector) latencyFor(r ProbeResult) time.Duration {
+	if r.Err != nil {
+		if lg, ok := s.lastGood[r.LineID]; ok {
+			return effectiveLatency(lg)
+		}
+	}
+	return effectiveLatency(r)
+}
+
 // Select 根据最新结果选线：锁线优先；否则取最快可用线路，且与当前线路的
 // 延迟差超过 tolerance 才切换（防抖）。
 func (s *Selector) Select() Selection {
@@ -280,9 +342,9 @@ func (s *Selector) Select() Selection {
 	defer s.mu.Unlock()
 
 	if s.lockedLine != "" {
-		if r, ok := s.results[s.lockedLine]; ok && r.Err == nil {
+		if r, ok := s.results[s.lockedLine]; ok && s.usable(r) {
 			s.current = s.lockedLine
-			return Selection{LineID: s.lockedLine, Locked: true, Latency: effectiveLatency(r)}
+			return Selection{LineID: s.lockedLine, Locked: true, Latency: s.latencyFor(r)}
 		}
 		// 锁定的线路失效：解除锁，退回自动模式。
 		s.lockedLine = ""
@@ -299,12 +361,12 @@ func (s *Selector) Select() Selection {
 	if s.current != "" {
 		cur, curOK := s.results[s.current]
 		bestR, bestOK := s.results[best]
-		if curOK && bestOK && cur.Err == nil && effectiveLatency(cur)-effectiveLatency(bestR) <= s.tolerance {
-			return Selection{LineID: s.current, Latency: effectiveLatency(cur)}
+		if curOK && bestOK && s.usable(cur) && s.latencyFor(cur)-s.latencyFor(bestR) <= s.tolerance {
+			return Selection{LineID: s.current, Latency: s.latencyFor(cur)}
 		}
 	}
 	s.current = best
-	return Selection{LineID: best, Latency: effectiveLatency(s.results[best])}
+	return Selection{LineID: best, Latency: s.latencyFor(s.results[best])}
 }
 
 // bestUsable 返回可用线路中延迟最小的一条；无可用时返回空串。
@@ -317,10 +379,10 @@ func (s *Selector) bestUsable() string {
 	}
 	var cands []cand
 	for id, r := range s.results {
-		if r.Err != nil {
+		if !s.usable(r) {
 			continue
 		}
-		cands = append(cands, cand{id: id, lat: effectiveLatency(r)})
+		cands = append(cands, cand{id: id, lat: s.latencyFor(r)})
 	}
 	if len(cands) == 0 {
 		return ""

--- a/backend/service/selector/selector_test.go
+++ b/backend/service/selector/selector_test.go
@@ -255,3 +255,95 @@ func TestProbeAllConcurrencyLimited(t *testing.T) {
 		t.Fatal("expected at least some concurrency")
 	}
 }
+
+func TestFailureThresholdTransientFailureKeepsLine(t *testing.T) {
+	// 阈值 2：a 瞬时失败一次（failStreak=1 < 2），仍应保持 a，不切线。
+	s, f := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 20 * time.Millisecond},
+		nil,
+	)
+	s.SetFailureThreshold(2)
+	s.ProbeAll(context.Background())
+	first := s.Select()
+	if first.LineID != "a" {
+		t.Fatalf("expected initial pick a, got %q", first.LineID)
+	}
+	f.errors = map[string]error{"a": &ProbeError{Reason: "timeout"}}
+	s.ProbeAll(context.Background())
+	second := s.Select()
+	if second.LineID != "a" {
+		t.Fatalf("expected keep a after one transient failure, got %q", second.LineID)
+	}
+	if second.Latency != 10*time.Millisecond {
+		t.Fatalf("expected fallback latency from lastGood 10ms, got %v", second.Latency)
+	}
+}
+
+func TestFailureThresholdPersistentFailureSwitches(t *testing.T) {
+	// 阈值 2：a 连续失败两次（failStreak=2 >= 2）后判不可用，切到 b。
+	s, f := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 20 * time.Millisecond},
+		nil,
+	)
+	s.SetFailureThreshold(2)
+	s.ProbeAll(context.Background())
+	if sel := s.Select(); sel.LineID != "a" {
+		t.Fatalf("expected initial pick a, got %q", sel.LineID)
+	}
+	f.errors = map[string]error{"a": &ProbeError{Reason: "timeout"}}
+	s.ProbeAll(context.Background()) // failStreak[a]=1
+	if sel := s.Select(); sel.LineID != "a" {
+		t.Fatalf("expected still a after 1 failure, got %q", sel.LineID)
+	}
+	s.ProbeAll(context.Background()) // failStreak[a]=2，达到阈值
+	third := s.Select()
+	if third.LineID != "b" {
+		t.Fatalf("expected switch to b after 2 failures, got %q", third.LineID)
+	}
+}
+
+func TestFailureThresholdRecoveryReturnsToFastest(t *testing.T) {
+	// 阈值 2：a 失败两次期间选到 b；a 恢复且延迟优势超过容差后，应自动切回 a。
+	// b 用 100ms 使 a(10) 与 b(100) 差 90ms > tolerance(50)，恢复后必然回切。
+	s, f := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 100 * time.Millisecond},
+		nil,
+	)
+	s.SetFailureThreshold(2)
+	s.ProbeAll(context.Background())
+	if sel := s.Select(); sel.LineID != "a" {
+		t.Fatalf("expected initial pick a, got %q", sel.LineID)
+	}
+	f.errors = map[string]error{"a": &ProbeError{Reason: "timeout"}}
+	s.ProbeAll(context.Background()) // failStreak[a]=1，仍保持 a
+	if sel := s.Select(); sel.LineID != "a" {
+		t.Fatalf("expected keep a after 1 failure, got %q", sel.LineID)
+	}
+	s.ProbeAll(context.Background()) // failStreak[a]=2，切到 b
+	if sel := s.Select(); sel.LineID != "b" {
+		t.Fatalf("expected b after 2 failures, got %q", sel.LineID)
+	}
+	delete(f.errors, "a") // a 恢复
+	s.ProbeAll(context.Background())
+	final := s.Select()
+	if final.LineID != "a" {
+		t.Fatalf("expected switch back to a after recovery, got %q", final.LineID)
+	}
+}
+
+func TestFailureThresholdNoLastGoodStaysUnusable(t *testing.T) {
+	// 从未成功过的线路即使失败次数低于阈值也不可用（无 lastGood 兜底）。
+	s, _ := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"b": 20 * time.Millisecond},
+		map[string]error{"a": &ProbeError{Reason: "refused"}},
+	)
+	s.SetFailureThreshold(3)
+	s.ProbeAll(context.Background()) // failStreak[a]=1
+	if sel := s.Select(); sel.LineID != "b" {
+		t.Fatalf("expected only b usable, got %q", sel.LineID)
+	}
+}

--- a/backend/service/selector/selector_test.go
+++ b/backend/service/selector/selector_test.go
@@ -3,40 +3,73 @@ package selector
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 )
 
 // fakeProber 注入式探测器：按线路 id 返回固定延迟/错误。
+// latencies/httpLatencies/errors 可变，测试可通过公开 API 路径（ProbeAll）
+// 模拟线路质量变化，而不是直接写 Selector 内部状态。
 type fakeProber struct {
-	latencies map[string]time.Duration
-	errors    map[string]error
+	latencies     map[string]time.Duration
+	httpLatencies map[string]time.Duration
+	errors        map[string]error
 }
 
 func (f *fakeProber) Probe(_ context.Context, line Line) ProbeResult {
 	if err := f.errors[line.ID]; err != nil {
 		return ProbeResult{LineID: line.ID, Err: err}
 	}
-	return ProbeResult{LineID: line.ID, TCPLatency: f.latencies[line.ID]}
+	res := ProbeResult{LineID: line.ID, TCPLatency: f.latencies[line.ID]}
+	if hl, ok := f.httpLatencies[line.ID]; ok {
+		res.HTTPLatency = hl
+	}
+	return res
+}
+
+// countingProber 包装器：统计最大并发探测数（验证信号量限流）。
+type countingProber struct {
+	inner  Prober
+	mu     sync.Mutex
+	active int
+	peak   int
+}
+
+func (c *countingProber) Probe(ctx context.Context, line Line) ProbeResult {
+	c.mu.Lock()
+	c.active++
+	if c.active > c.peak {
+		c.peak = c.active
+	}
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		c.active--
+		c.mu.Unlock()
+	}()
+	// 让探测留出重叠窗口，才能测出真实并发上限。
+	time.Sleep(20 * time.Millisecond)
+	return c.inner.Probe(ctx, line)
 }
 
 func mkLines(ids ...string) []Line {
 	lines := make([]Line, 0, len(ids))
-	for i, id := range ids {
+	for _, id := range ids {
 		lines = append(lines, Line{ID: id, Name: id, Tool: "fake", Address: "127.0.0.1:1"})
-		_ = i
 	}
 	return lines
 }
 
-func newFake(lines []Line, lat map[string]time.Duration, errs map[string]error) *Selector {
-	s := NewSelector(&fakeProber{latencies: lat, errors: errs}, 50*time.Millisecond)
+func newFake(lines []Line, lat map[string]time.Duration, errs map[string]error) (*Selector, *fakeProber) {
+	f := &fakeProber{latencies: lat, errors: errs}
+	s := NewSelector(f, 50*time.Millisecond)
 	s.SetLines(lines)
-	return s
+	return s, f
 }
 
 func TestSelectPicksFastest(t *testing.T) {
-	s := newFake(
+	s, _ := newFake(
 		mkLines("a", "b", "c"),
 		map[string]time.Duration{"a": 300 * time.Millisecond, "b": 100 * time.Millisecond, "c": 200 * time.Millisecond},
 		nil,
@@ -51,8 +84,31 @@ func TestSelectPicksFastest(t *testing.T) {
 	}
 }
 
+func TestSelectPrefersHTTPLatencyWhenProbed(t *testing.T) {
+	// b 的 TCP 握手更慢，但 HTTP 出网更快；配置了 ProbeURL 时应选 b。
+	// 覆盖 #B 修复：测速结果里的 HTTP 延迟参与选线排序。
+	lines := []Line{
+		{ID: "a", Name: "a", Tool: "fake", Address: "127.0.0.1:1", ProbeURL: "http://a/probe"},
+		{ID: "b", Name: "b", Tool: "fake", Address: "127.0.0.1:1", ProbeURL: "http://b/probe"},
+	}
+	f := &fakeProber{
+		latencies:     map[string]time.Duration{"a": 10 * time.Millisecond, "b": 30 * time.Millisecond},
+		httpLatencies: map[string]time.Duration{"a": 200 * time.Millisecond, "b": 20 * time.Millisecond},
+	}
+	s := NewSelector(f, 50*time.Millisecond)
+	s.SetLines(lines)
+	s.ProbeAll(context.Background())
+	sel := s.Select()
+	if sel.LineID != "b" {
+		t.Fatalf("expected HTTP-fastest b, got %q", sel.LineID)
+	}
+	if sel.Latency != 20*time.Millisecond {
+		t.Fatalf("expected effective latency 20ms, got %v", sel.Latency)
+	}
+}
+
 func TestSelectSkipsUnavailableLines(t *testing.T) {
-	s := newFake(
+	s, _ := newFake(
 		mkLines("a", "b"),
 		map[string]time.Duration{"b": 100 * time.Millisecond},
 		map[string]error{"a": &ProbeError{Reason: "refused"}},
@@ -65,7 +121,7 @@ func TestSelectSkipsUnavailableLines(t *testing.T) {
 }
 
 func TestSelectEmptyWhenAllDown(t *testing.T) {
-	s := newFake(
+	s, _ := newFake(
 		mkLines("a", "b"),
 		nil,
 		map[string]error{"a": errors.New("down"), "b": errors.New("down")},
@@ -79,7 +135,7 @@ func TestSelectEmptyWhenAllDown(t *testing.T) {
 
 func TestToleranceHysteresis(t *testing.T) {
 	// a=90ms、b=100ms：首次 Select（无当前线路）直接选最快 a。
-	s := newFake(
+	s, f := newFake(
 		mkLines("a", "b"),
 		map[string]time.Duration{"a": 90 * time.Millisecond, "b": 100 * time.Millisecond},
 		nil,
@@ -90,13 +146,15 @@ func TestToleranceHysteresis(t *testing.T) {
 		t.Fatalf("first select should pick fastest a, got %q", first.LineID)
 	}
 	// b 提升到 40ms：a(90)-b(40)=50 <= tolerance(50) → 保持 a，不抖动。
-	s.results["b"] = ProbeResult{LineID: "b", TCPLatency: 40 * time.Millisecond}
+	f.latencies["b"] = 40 * time.Millisecond
+	s.ProbeAll(context.Background())
 	second := s.Select()
 	if second.LineID != "a" {
 		t.Fatalf("expected hysteresis keep a, got %q", second.LineID)
 	}
 	// b 提升到 30ms：a(90)-b(30)=60 > tolerance(50) → 切到 b。
-	s.results["b"] = ProbeResult{LineID: "b", TCPLatency: 30 * time.Millisecond}
+	f.latencies["b"] = 30 * time.Millisecond
+	s.ProbeAll(context.Background())
 	third := s.Select()
 	if third.LineID != "b" {
 		t.Fatalf("expected switch to b after big gap, got %q", third.LineID)
@@ -104,7 +162,7 @@ func TestToleranceHysteresis(t *testing.T) {
 }
 
 func TestLockOverridesAutoAndUnlockRestores(t *testing.T) {
-	s := newFake(
+	s, _ := newFake(
 		mkLines("a", "b"),
 		map[string]time.Duration{"a": 300 * time.Millisecond, "b": 100 * time.Millisecond},
 		nil,
@@ -123,7 +181,7 @@ func TestLockOverridesAutoAndUnlockRestores(t *testing.T) {
 }
 
 func TestLockUnknownLineIgnored(t *testing.T) {
-	s := newFake(mkLines("a"), map[string]time.Duration{"a": 10 * time.Millisecond}, nil)
+	s, _ := newFake(mkLines("a"), map[string]time.Duration{"a": 10 * time.Millisecond}, nil)
 	s.ProbeAll(context.Background())
 	s.Lock("does-not-exist")
 	if s.lockedLine != "" {
@@ -132,7 +190,7 @@ func TestLockUnknownLineIgnored(t *testing.T) {
 }
 
 func TestLockReleasedWhenLineDies(t *testing.T) {
-	s := newFake(
+	s, f := newFake(
 		mkLines("a", "b"),
 		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 20 * time.Millisecond},
 		nil,
@@ -140,7 +198,8 @@ func TestLockReleasedWhenLineDies(t *testing.T) {
 	s.ProbeAll(context.Background())
 	s.Lock("a")
 	// a 失效 → Select 应解除锁并退回可用线路 b。
-	s.results["a"] = ProbeResult{LineID: "a", Err: &ProbeError{Reason: "timeout"}}
+	f.errors = map[string]error{"a": &ProbeError{Reason: "timeout"}}
+	s.ProbeAll(context.Background())
 	sel := s.Select()
 	if sel.Locked {
 		t.Fatal("expected lock to be released")
@@ -151,7 +210,7 @@ func TestLockReleasedWhenLineDies(t *testing.T) {
 }
 
 func TestSetLinesPrunesStaleResultsAndDeadLock(t *testing.T) {
-	s := newFake(
+	s, _ := newFake(
 		mkLines("a", "b"),
 		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 20 * time.Millisecond},
 		nil,
@@ -168,11 +227,31 @@ func TestSetLinesPrunesStaleResultsAndDeadLock(t *testing.T) {
 }
 
 func TestSnapshotThreadSafe(t *testing.T) {
-	s := newFake(mkLines("a"), map[string]time.Duration{"a": 10 * time.Millisecond}, nil)
+	s, _ := newFake(mkLines("a"), map[string]time.Duration{"a": 10 * time.Millisecond}, nil)
 	s.ProbeAll(context.Background())
 	s.Select()
 	st := s.Snapshot()
 	if len(st.Lines) != 1 || st.Current != "a" {
 		t.Fatalf("unexpected snapshot: %+v", st)
+	}
+}
+
+func TestProbeAllConcurrencyLimited(t *testing.T) {
+	// 8 条线路、并发上限 3：实测最大并发必须 <= 3（覆盖 #D 信号量限流）。
+	f := &fakeProber{
+		latencies: map[string]time.Duration{
+			"a": 1, "b": 1, "c": 1, "d": 1, "e": 1, "f": 1, "g": 1, "h": 1,
+		},
+	}
+	counter := &countingProber{inner: f}
+	s := NewSelector(counter, 50*time.Millisecond)
+	s.SetMaxConcurrent(3)
+	s.SetLines(mkLines("a", "b", "c", "d", "e", "f", "g", "h"))
+	s.ProbeAll(context.Background())
+	if counter.peak > 3 {
+		t.Fatalf("expected peak concurrency <= 3, got %d", counter.peak)
+	}
+	if counter.peak < 1 {
+		t.Fatal("expected at least some concurrency")
 	}
 }

--- a/backend/service/selector/selector_test.go
+++ b/backend/service/selector/selector_test.go
@@ -1,0 +1,178 @@
+package selector
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeProber 注入式探测器：按线路 id 返回固定延迟/错误。
+type fakeProber struct {
+	latencies map[string]time.Duration
+	errors    map[string]error
+}
+
+func (f *fakeProber) Probe(_ context.Context, line Line) ProbeResult {
+	if err := f.errors[line.ID]; err != nil {
+		return ProbeResult{LineID: line.ID, Err: err}
+	}
+	return ProbeResult{LineID: line.ID, TCPLatency: f.latencies[line.ID]}
+}
+
+func mkLines(ids ...string) []Line {
+	lines := make([]Line, 0, len(ids))
+	for i, id := range ids {
+		lines = append(lines, Line{ID: id, Name: id, Tool: "fake", Address: "127.0.0.1:1"})
+		_ = i
+	}
+	return lines
+}
+
+func newFake(lines []Line, lat map[string]time.Duration, errs map[string]error) *Selector {
+	s := NewSelector(&fakeProber{latencies: lat, errors: errs}, 50*time.Millisecond)
+	s.SetLines(lines)
+	return s
+}
+
+func TestSelectPicksFastest(t *testing.T) {
+	s := newFake(
+		mkLines("a", "b", "c"),
+		map[string]time.Duration{"a": 300 * time.Millisecond, "b": 100 * time.Millisecond, "c": 200 * time.Millisecond},
+		nil,
+	)
+	s.ProbeAll(context.Background())
+	sel := s.Select()
+	if sel.LineID != "b" {
+		t.Fatalf("expected fastest line b, got %q", sel.LineID)
+	}
+	if sel.Locked {
+		t.Fatal("expected auto mode, got locked")
+	}
+}
+
+func TestSelectSkipsUnavailableLines(t *testing.T) {
+	s := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"b": 100 * time.Millisecond},
+		map[string]error{"a": &ProbeError{Reason: "refused"}},
+	)
+	s.ProbeAll(context.Background())
+	sel := s.Select()
+	if sel.LineID != "b" {
+		t.Fatalf("expected fallback to b, got %q", sel.LineID)
+	}
+}
+
+func TestSelectEmptyWhenAllDown(t *testing.T) {
+	s := newFake(
+		mkLines("a", "b"),
+		nil,
+		map[string]error{"a": errors.New("down"), "b": errors.New("down")},
+	)
+	s.ProbeAll(context.Background())
+	sel := s.Select()
+	if sel.LineID != "" {
+		t.Fatalf("expected empty selection, got %q", sel.LineID)
+	}
+}
+
+func TestToleranceHysteresis(t *testing.T) {
+	// a=90ms、b=100ms：首次 Select（无当前线路）直接选最快 a。
+	s := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 90 * time.Millisecond, "b": 100 * time.Millisecond},
+		nil,
+	)
+	s.ProbeAll(context.Background())
+	first := s.Select()
+	if first.LineID != "a" {
+		t.Fatalf("first select should pick fastest a, got %q", first.LineID)
+	}
+	// b 提升到 40ms：a(90)-b(40)=50 <= tolerance(50) → 保持 a，不抖动。
+	s.results["b"] = ProbeResult{LineID: "b", TCPLatency: 40 * time.Millisecond}
+	second := s.Select()
+	if second.LineID != "a" {
+		t.Fatalf("expected hysteresis keep a, got %q", second.LineID)
+	}
+	// b 提升到 30ms：a(90)-b(30)=60 > tolerance(50) → 切到 b。
+	s.results["b"] = ProbeResult{LineID: "b", TCPLatency: 30 * time.Millisecond}
+	third := s.Select()
+	if third.LineID != "b" {
+		t.Fatalf("expected switch to b after big gap, got %q", third.LineID)
+	}
+}
+
+func TestLockOverridesAutoAndUnlockRestores(t *testing.T) {
+	s := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 300 * time.Millisecond, "b": 100 * time.Millisecond},
+		nil,
+	)
+	s.ProbeAll(context.Background())
+	s.Lock("a")
+	sel := s.Select()
+	if !sel.Locked || sel.LineID != "a" {
+		t.Fatalf("expected locked a, got %+v", sel)
+	}
+	s.Unlock()
+	sel = s.Select()
+	if sel.Locked || sel.LineID != "b" {
+		t.Fatalf("expected auto back to b, got %+v", sel)
+	}
+}
+
+func TestLockUnknownLineIgnored(t *testing.T) {
+	s := newFake(mkLines("a"), map[string]time.Duration{"a": 10 * time.Millisecond}, nil)
+	s.ProbeAll(context.Background())
+	s.Lock("does-not-exist")
+	if s.lockedLine != "" {
+		t.Fatalf("unknown lock should be ignored, got %q", s.lockedLine)
+	}
+}
+
+func TestLockReleasedWhenLineDies(t *testing.T) {
+	s := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 20 * time.Millisecond},
+		nil,
+	)
+	s.ProbeAll(context.Background())
+	s.Lock("a")
+	// a 失效 → Select 应解除锁并退回可用线路 b。
+	s.results["a"] = ProbeResult{LineID: "a", Err: &ProbeError{Reason: "timeout"}}
+	sel := s.Select()
+	if sel.Locked {
+		t.Fatal("expected lock to be released")
+	}
+	if sel.LineID != "b" {
+		t.Fatalf("expected fallback to b, got %q", sel.LineID)
+	}
+}
+
+func TestSetLinesPrunesStaleResultsAndDeadLock(t *testing.T) {
+	s := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 20 * time.Millisecond},
+		nil,
+	)
+	s.ProbeAll(context.Background())
+	s.Lock("a")
+	s.SetLines(mkLines("b", "c"))
+	if _, ok := s.results["a"]; ok {
+		t.Fatal("stale result for removed line a should be pruned")
+	}
+	if s.lockedLine != "" {
+		t.Fatal("lock on removed line should be released")
+	}
+}
+
+func TestSnapshotThreadSafe(t *testing.T) {
+	s := newFake(mkLines("a"), map[string]time.Duration{"a": 10 * time.Millisecond}, nil)
+	s.ProbeAll(context.Background())
+	s.Select()
+	st := s.Snapshot()
+	if len(st.Lines) != 1 || st.Current != "a" {
+		t.Fatalf("unexpected snapshot: %+v", st)
+	}
+}


### PR DESCRIPTION
## What
自动测速选线方向（refs #3）与模块化底座（refs #4）的第一步：独立的 `backend/service/selector` 包。

## Change
- **Line** — 工具无关的隧道入口抽象（frp/nps/easytier/wireguard…）：ID/Name/Tool/Address/ProbeURL
- **TCPProber** — TCP 握手延迟 + 可选 HTTP 204 探测，超时保护、context-aware
- **Selector** — 并发 ProbeAll、滞回自动选线（防抖动）、手动 Lock/Unlock、线路变更清理、死锁自动释放、后台守护循环
- **Snapshot** — 线程安全状态快照（供 API/UI）

## Tests
9 个单元测试（注入 fake prober，无网络）：`go test ./service/selector/` 9/9 通过，go vet/gofmt 干净。

## Notes
纯 stdlib 核心，无接线。后续 PR 按依赖顺序：linereg 注册中心 → cftunnel → tunservice → 切换落地。Refs #3 #4