### PR TITLE
[Feature] 端口层切换重绑 + Quick 隧道入口 / Port-level switch rebinding + Quick tunnel entry (#10)

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -228,6 +228,9 @@ func startServer() *http.Server {
 
 	// 线路注册中心：汇总 frp/nps/easytier/wg 入口为线路，驱动自动测速选线
 	lineregMgr := linereg.NewManager(db, log, 0)
+	// 切换落地：选线结果变化时热加载 Caddy 反代目标（域名层）与 DNS 解析（DNS 层）
+	lineregMgr.SetCaddyUpdater(caddyMgr.UpdateUpstream)
+	lineregMgr.SetDNSUpdater(dnsmasqMgr.SetRecord)
 
 	// 穿透服务层（用户视角）：聚合各工具线路，支持统一启停
 	tunserviceMgr := tunservice.NewManager(db, log, lineregMgr,

--- a/backend/main.go
+++ b/backend/main.go
@@ -235,6 +235,8 @@ func startServer() *http.Server {
 	// 穿透服务层（用户视角）：聚合各工具线路，支持统一启停
 	tunserviceMgr := tunservice.NewManager(db, log, lineregMgr,
 		frpMgr, npsMgr, easytierMgr, wireguardMgr, cftunnelMgr)
+	// 端口层切换落地：选线变化时自动重绑未绑定 Caddy/DNS 的 TCP/UDP 穿透服务
+	lineregMgr.SetPortRebinder(tunserviceMgr.RebindPort)
 
 	wireguardMgr.StartAll()
 

--- a/backend/model/models.go
+++ b/backend/model/models.go
@@ -569,7 +569,10 @@ type CftunnelConfig struct {
 	// token 模式：远程配置 token（cloudflared tunnel run --token）
 	Token string `gorm:"type:text" json:"token"`
 	// 协议：http/https，默认 http
-	Protocol  string `gorm:"size:20;default:'http'" json:"protocol"`
+	Protocol string `gorm:"size:20;default:'http'" json:"protocol"`
+	// QuickURL quick 模式的临时隧道地址（每次启动随机生成，
+	// 从 cloudflared stdout 自动提取，供前端直接展示可访问入口）
+	QuickURL  string `gorm:"size:500" json:"quick_url"`
 	Status    string `gorm:"size:20;default:'stopped'" json:"status"`
 	LastError string `gorm:"type:text" json:"last_error"`
 	Remark    string `gorm:"size:500" json:"remark"`

--- a/backend/model/models.go
+++ b/backend/model/models.go
@@ -587,7 +587,13 @@ type TunService struct {
 	TargetPort    int    `gorm:"not null" json:"target_port"`
 	Protocol      string `gorm:"size:10;default:'tcp'" json:"protocol"` // tcp/udp
 	// LineRefs 关联线路 ID 列表（JSON 数组，如 ["frp:1","cftunnel:2"]）
-	LineRefs  string `gorm:"type:text" json:"line_refs"`
+	LineRefs string `gorm:"type:text" json:"line_refs"`
+	// CaddySiteID 绑定的 Caddy 反向代理站点 ID（0 表示不绑定）。
+	// 选线结果变化时，会把该站点的上游目标动态切换为当前线路的入口。
+	CaddySiteID uint `gorm:"default:0" json:"caddy_site_id"`
+	// Domain 对外服务域名（可选）。选线结果变化时，若线路入口为 IP，
+	// 会通过 dnsmasq 自定义解析记录把该域名指向当前线路入口（DNS 层切换）。
+	Domain    string `gorm:"size:255" json:"domain"`
 	Status    string `gorm:"size:20;default:'stopped'" json:"status"`
 	LastError string `gorm:"type:text" json:"last_error"`
 	Remark    string `gorm:"size:500" json:"remark"`

--- a/backend/service/caddy/manager.go
+++ b/backend/service/caddy/manager.go
@@ -172,6 +172,44 @@ func (m *Manager) Restart(id uint) error {
 	return m.Start(id)
 }
 
+// UpdateUpstream 动态更新反向代理站点的上游目标并热加载（不落库）。
+// 用于自动选线切换：选线结果变化时，把 Caddy 反代目标指向当前线路的入口。
+func (m *Manager) UpdateUpstream(id uint, upstream string) error {
+	var site model.CaddySite
+	if err := m.db.First(&site, id).Error; err != nil {
+		return fmt.Errorf("站点不存在: %w", err)
+	}
+	if site.SiteType != "reverse_proxy" {
+		return fmt.Errorf("仅反向代理站点支持动态切换上游，当前类型: %s", site.SiteType)
+	}
+	if upstream == "" {
+		return fmt.Errorf("上游目标地址不能为空")
+	}
+	if err := m.ensureCaddyRunning(); err != nil {
+		return fmt.Errorf("Caddy 引擎未就绪: %w", err)
+	}
+
+	// 内存中替换上游目标，不写库（保留用户原始配置，重启后回退）
+	site.UpstreamAddr = upstream
+	routes, err := m.buildRoutes(&site)
+	if err != nil {
+		m.setError(id, err.Error())
+		return fmt.Errorf("构建路由配置失败: %w", err)
+	}
+	serverKey := fmt.Sprintf("netpanel_%d", id)
+	serverCfg := m.buildServerConfig(&site, routes)
+
+	if err := m.adminRequest("PUT",
+		fmt.Sprintf("/config/apps/http/servers/%s", serverKey),
+		serverCfg,
+	); err != nil {
+		m.setError(id, err.Error())
+		return fmt.Errorf("热加载站点配置失败: %w", err)
+	}
+	m.log.Infof("[Caddy] 站点 [%s] 上游目标已切换为 %s", site.Name, upstream)
+	return nil
+}
+
 // GetStatus 获取站点状态
 func (m *Manager) GetStatus(id uint) string {
 	var site model.CaddySite

--- a/backend/service/caddy/manager.go
+++ b/backend/service/caddy/manager.go
@@ -185,6 +185,9 @@ func (m *Manager) UpdateUpstream(id uint, upstream string) error {
 	if upstream == "" {
 		return fmt.Errorf("上游目标地址不能为空")
 	}
+	if err := validateUpstream(upstream); err != nil {
+		return err
+	}
 	if err := m.ensureCaddyRunning(); err != nil {
 		return fmt.Errorf("Caddy 引擎未就绪: %w", err)
 	}
@@ -645,6 +648,27 @@ func (m *Manager) setError(id uint, errMsg string) {
 // GetCaddyDataDir 获取 Caddy 数据目录
 func (m *Manager) GetCaddyDataDir() string {
 	return filepath.Join(m.dataDir, "caddy")
+}
+
+// validateUpstream 校验上游目标地址格式，防止非法值损坏 Caddy 配置。
+// 允许 host:port（如 1.2.3.4:7000）或带协议前缀（http:// / https://）的形式；
+// 复用 normalizeUpstreamDial 的规范化逻辑，能解析出合法 host:port 即通过。
+func validateUpstream(upstream string) error {
+	addr := normalizeUpstreamDial(upstream)
+	if addr == "" {
+		return fmt.Errorf("非法上游目标地址: %q", upstream)
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil || host == "" {
+		return fmt.Errorf("非法上游目标地址: %q", upstream)
+	}
+	// 拒绝含空白/控制字符的地址（可能注入 Caddy 配置）
+	for _, r := range addr {
+		if r <= ' ' {
+			return fmt.Errorf("非法上游目标地址（含空白字符）: %q", upstream)
+		}
+	}
+	return nil
 }
 
 // normalizeUpstreamDial 将上游地址转换为 Caddy reverse_proxy 的 dial 格式 (host:port)

--- a/backend/service/cftunnel/manager.go
+++ b/backend/service/cftunnel/manager.go
@@ -32,7 +32,7 @@ const (
 
 // quickURLRe 匹配 cloudflared quick 模式日志中的临时隧道地址，
 // 形如 https://<random>.trycloudflare.com
-var quickURLRe = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
+var quickURLRe = regexp.MustCompile(`(?i)https://[a-z0-9-]+\.trycloudflare\.com(?:\s|$)`)
 
 // processEntry 单个 cloudflared 进程
 type processEntry struct {
@@ -184,6 +184,7 @@ func (m *Manager) Start(id uint) error {
 	m.tunnels.Store(id, entry)
 
 	go func() {
+		defer m.log.Debugf("[CF隧道][%d] stdout 监听已退出", id)
 		scanner := bufio.NewScanner(stdoutPipe)
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -199,6 +200,7 @@ func (m *Manager) Start(id uint) error {
 		}
 	}()
 	go func() {
+		defer m.log.Debugf("[CF隧道][%d] stderr 监听已退出", id)
 		scanner := bufio.NewScanner(stderrPipe)
 		for scanner.Scan() {
 			line := scanner.Text()

--- a/backend/service/cftunnel/manager.go
+++ b/backend/service/cftunnel/manager.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"time"
 
@@ -28,6 +29,10 @@ const (
 	// configDirName named 模式临时配置目录
 	configDirName = "cftunnel"
 )
+
+// quickURLRe 匹配 cloudflared quick 模式日志中的临时隧道地址，
+// 形如 https://<random>.trycloudflare.com
+var quickURLRe = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 
 // processEntry 单个 cloudflared 进程
 type processEntry struct {
@@ -181,7 +186,16 @@ func (m *Manager) Start(id uint) error {
 	go func() {
 		scanner := bufio.NewScanner(stdoutPipe)
 		for scanner.Scan() {
-			logBuf.write(scanner.Text())
+			line := scanner.Text()
+			logBuf.write(line)
+			// quick 模式：隧道地址每次启动随机生成，从日志中提取并落库，
+			// 前端可直接展示可访问入口，无需翻日志
+			if cfg.Mode == "quick" {
+				if url := quickURLRe.FindString(line); url != "" {
+					m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Update("quick_url", url)
+					m.log.Infof("[CF隧道][%d] quick 入口已更新: %s", id, url)
+				}
+			}
 		}
 	}()
 	go func() {
@@ -204,6 +218,7 @@ func (m *Manager) Start(id uint) error {
 			m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
 				"status":     "error",
 				"last_error": errMsg,
+				"quick_url":  "",
 			})
 			// 自动重启（延迟 5 秒，关闭期间不重启）
 			time.Sleep(5 * time.Second)
@@ -221,7 +236,10 @@ func (m *Manager) Start(id uint) error {
 				}
 			}
 		} else {
-			m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Update("status", "stopped")
+			m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
+				"status":    "stopped",
+				"quick_url": "",
+			})
 			m.log.Infof("[CF隧道][%d] 进程已退出", id)
 		}
 	}()
@@ -245,7 +263,11 @@ func (m *Manager) Stop(id uint) {
 		<-entry.done
 		m.tunnels.Delete(id)
 	}
-	m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Update("status", "stopped")
+	// 进程停止后 quick 隧道地址随即失效，一并清理
+	m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"status":    "stopped",
+		"quick_url": "",
+	})
 }
 
 // Restart 重启指定隧道

--- a/backend/service/dnsmasq/manager.go
+++ b/backend/service/dnsmasq/manager.go
@@ -105,8 +105,13 @@ func (m *Manager) GetStatus() string {
 // 用于自动选线的 DNS 层切换：把服务域名指向当前线路入口 IP。
 func (m *Manager) SetRecord(domain, ip string) error {
 	domain = strings.TrimSuffix(strings.TrimSpace(domain), ".")
-	if domain == "" || strings.TrimSpace(ip) == "" {
+	ip = strings.TrimSpace(ip)
+	if domain == "" || ip == "" {
 		return fmt.Errorf("域名和 IP 不能为空")
+	}
+	// 校验 IP 合法性，防止非法值污染 DNS 解析
+	if net.ParseIP(ip) == nil {
+		return fmt.Errorf("非法 IP 地址: %s", ip)
 	}
 	var record model.DnsmasqRecord
 	err := m.db.Where("domain = ?", domain).First(&record).Error

--- a/backend/service/dnsmasq/manager.go
+++ b/backend/service/dnsmasq/manager.go
@@ -100,6 +100,30 @@ func (m *Manager) GetStatus() string {
 	return "stopped"
 }
 
+// SetRecord 新增或更新自定义解析记录（域名 → IP）。
+// handleDNS 每次查询都直接读库，因此写入后立即生效，无需重载。
+// 用于自动选线的 DNS 层切换：把服务域名指向当前线路入口 IP。
+func (m *Manager) SetRecord(domain, ip string) error {
+	domain = strings.TrimSuffix(strings.TrimSpace(domain), ".")
+	if domain == "" || strings.TrimSpace(ip) == "" {
+		return fmt.Errorf("域名和 IP 不能为空")
+	}
+	var record model.DnsmasqRecord
+	err := m.db.Where("domain = ?", domain).First(&record).Error
+	if err == nil {
+		record.IP = strings.TrimSpace(ip)
+		record.Enable = true
+		return m.db.Save(&record).Error
+	}
+	record = model.DnsmasqRecord{
+		Domain: domain,
+		IP:     strings.TrimSpace(ip),
+		Enable: true,
+		Remark: "自动选线切换",
+	}
+	return m.db.Create(&record).Error
+}
+
 // handleDNS 处理 DNS 查询
 func (m *Manager) handleDNS(w dns.ResponseWriter, r *dns.Msg) {
 	msg := new(dns.Msg)

--- a/backend/service/linereg/linereg.go
+++ b/backend/service/linereg/linereg.go
@@ -42,6 +42,11 @@ type Manager struct {
 	// 由上层注入（main.go），避免本包依赖 dnsmasq。
 	dnsUpdater func(domain, ip string) error
 
+	// lastUpstream 记录每个 Caddy 站点最近一次成功切换的上游目标（siteID -> upstream）。
+	// 切换失败时回滚到该值，避免 Caddy 反代目标与选中线路不一致。
+	lastUpstream map[uint]string
+	lastMu       sync.Mutex
+
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 }
@@ -52,10 +57,11 @@ func NewManager(db *gorm.DB, log *logrus.Logger, tolerance time.Duration) *Manag
 		log = logrus.New()
 	}
 	return &Manager{
-		db:       db,
-		log:      log,
-		interval: DefaultInterval,
-		selector: selector.NewSelector(nil, tolerance),
+		db:           db,
+		log:          log,
+		interval:     DefaultInterval,
+		selector:     selector.NewSelector(nil, tolerance),
+		lastUpstream: make(map[uint]string),
 	}
 }
 
@@ -176,8 +182,25 @@ func (m *Manager) applyCaddySwitch(lineID string) {
 				continue
 			}
 			if err := m.caddyUpdater(svc.CaddySiteID, line.Address); err != nil {
-				m.log.Warnf("[线路选择] 更新 Caddy 站点 %d 失败: %v", svc.CaddySiteID, err)
+				m.log.Errorf("[线路选择] 更新 Caddy 站点 %d 失败: %v", svc.CaddySiteID, err)
+				// 回滚到上一次成功切换的上游目标，避免 Caddy 与新线路不一致
+				m.lastMu.Lock()
+				old, ok := m.lastUpstream[svc.CaddySiteID]
+				m.lastMu.Unlock()
+				if ok && old != "" && old != line.Address {
+					if rerr := m.caddyUpdater(svc.CaddySiteID, old); rerr != nil {
+						m.log.Errorf("[线路选择] 回滚 Caddy 站点 %d 到 %s 失败: %v", svc.CaddySiteID, old, rerr)
+					} else {
+						m.log.Warnf("[线路选择] Caddy 站点 %d 已回滚到 %s", svc.CaddySiteID, old)
+					}
+				}
+				// 记录错误供 UI 排查
+				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
 			} else {
+				m.lastMu.Lock()
+				m.lastUpstream[svc.CaddySiteID] = line.Address
+				m.lastMu.Unlock()
+				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
 				m.log.Infof("[线路选择] Caddy 站点 %d 反代目标已切换为 %s", svc.CaddySiteID, line.Address)
 			}
 			break
@@ -221,7 +244,10 @@ func (m *Manager) applyDNSSwitch(lineID string) {
 			}
 			if err := m.dnsUpdater(svc.Domain, host); err != nil {
 				m.log.Warnf("[线路选择] 更新 DNS 解析 %s -> %s 失败: %v", svc.Domain, host, err)
+				// 记录错误供 UI 排查
+				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
 			} else {
+				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
 				m.log.Infof("[线路选择] DNS 解析 %s -> %s 已切换", svc.Domain, host)
 			}
 			break

--- a/backend/service/linereg/linereg.go
+++ b/backend/service/linereg/linereg.go
@@ -41,6 +41,11 @@ type Manager struct {
 	// dnsUpdater 选线切换回调：把服务域名指向选中线路入口 IP（DNS 层切换）。
 	// 由上层注入（main.go），避免本包依赖 dnsmasq。
 	dnsUpdater func(domain, ip string) error
+	// portRebinder 选线切换回调：重建端口层服务的穿透规则（先停后起，
+	// 短暂抖动可接受），把本地监听入口重新绑定到当前选中线路。
+	// 仅作用于未绑定 Caddy 站点、未配置域名的纯 TCP/UDP 端口层服务。
+	// 由上层注入（main.go），避免本包依赖各工具 manager。
+	portRebinder func(svcID uint, lineID string) error
 
 	// lastUpstream 记录每个 Caddy 站点最近一次成功切换的上游目标（siteID -> upstream）。
 	// 切换失败时回滚到该值，避免 Caddy 反代目标与选中线路不一致。
@@ -99,6 +104,13 @@ func (m *Manager) SetDNSUpdater(fn func(domain, ip string) error) {
 	m.dnsUpdater = fn
 }
 
+// SetPortRebinder 注入端口层切换回调（端口层切换落地）。
+// 选线结果变化时，会重建未绑定 Caddy/DNS 的纯 TCP/UDP 服务的穿透规则，
+// 使本地监听入口跟随当前选中线路。
+func (m *Manager) SetPortRebinder(fn func(svcID uint, lineID string) error) {
+	m.portRebinder = fn
+}
+
 // Start 启动后台守护：立即执行一轮刷新与测速，之后按 interval 周期循环。
 func (m *Manager) Start() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -143,9 +155,11 @@ func (m *Manager) refresh(ctx context.Context) {
 	m.selector.ProbeAll(ctx)
 	sel := m.selector.Select()
 	m.saveHistory()
-	// 切换落地：选线结果同步到绑定的 Caddy 站点（域名层）与 DNS 解析（DNS 层）
+	// 切换落地：选线结果同步到绑定的 Caddy 站点（域名层）、DNS 解析（DNS 层）
+	// 与未绑定 Caddy/DNS 的端口层服务（端口层重绑）
 	m.applyCaddySwitch(sel.LineID)
 	m.applyDNSSwitch(sel.LineID)
+	m.applyPortSwitch(sel.LineID)
 	m.log.Infof("[线路选择] 共 %d 条线路，当前线路: %q", len(lines), sel.LineID)
 }
 
@@ -249,6 +263,42 @@ func (m *Manager) applyDNSSwitch(lineID string) {
 			} else {
 				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
 				m.log.Infof("[线路选择] DNS 解析 %s -> %s 已切换", svc.Domain, host)
+			}
+			break
+		}
+	}
+}
+
+// applyPortSwitch 将当前选中线路同步到端口层服务（端口层切换落地）。
+// 端口层服务 = 未绑定 Caddy 站点（caddy_site_id=0）且未配置域名
+// （domain 为空）的纯 TCP/UDP 服务——HTTP/HTTPS 走域名层（Caddy），
+// 带域名的走 DNS 层，其余走端口映射。选线变化时重建受影响规则，
+// 把本地监听入口重新绑定到当前线路（先停后起，短暂抖动可接受）。
+func (m *Manager) applyPortSwitch(lineID string) {
+	if lineID == "" || m.portRebinder == nil {
+		return
+	}
+	var services []model.TunService
+	if err := m.db.Where("caddy_site_id = ? AND (domain IS NULL OR domain = '')", 0).Find(&services).Error; err != nil {
+		m.log.Warnf("[线路选择] 查询端口层服务失败: %v", err)
+		return
+	}
+	for _, svc := range services {
+		var refs []string
+		if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err != nil {
+			continue
+		}
+		for _, ref := range refs {
+			if ref != lineID {
+				continue
+			}
+			if err := m.portRebinder(svc.ID, lineID); err != nil {
+				m.log.Errorf("[线路选择] 端口层服务 %d 重绑线路 %s 失败: %v", svc.ID, lineID, err)
+				// 记录错误供 UI 排查
+				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
+			} else {
+				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
+				m.log.Infof("[线路选择] 端口层服务 %d 已重绑到线路 %s", svc.ID, lineID)
 			}
 			break
 		}

--- a/backend/service/linereg/linereg.go
+++ b/backend/service/linereg/linereg.go
@@ -10,7 +10,9 @@ package linereg
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,6 +34,13 @@ type Manager struct {
 	log      *logrus.Logger
 	interval time.Duration
 	selector *selector.Selector
+
+	// caddyUpdater 选线切换回调：把选中线路的入口同步到绑定的 Caddy 站点。
+	// 由上层注入（main.go），避免本包依赖 caddy。
+	caddyUpdater func(siteID uint, upstream string) error
+	// dnsUpdater 选线切换回调：把服务域名指向选中线路入口 IP（DNS 层切换）。
+	// 由上层注入（main.go），避免本包依赖 dnsmasq。
+	dnsUpdater func(domain, ip string) error
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -70,6 +79,18 @@ func (m *Manager) SetMaxConcurrent(n int) {
 // SetFailureThreshold 透传设置连续失败阈值（须在 Start 前调用）。
 func (m *Manager) SetFailureThreshold(n int) {
 	m.selector.SetFailureThreshold(n)
+}
+
+// SetCaddyUpdater 注入 Caddy 反代目标切换回调（域名层切换落地）。
+// 选线结果变化时，会把选中线路的入口地址同步到绑定了该线路的 Caddy 站点。
+func (m *Manager) SetCaddyUpdater(fn func(siteID uint, upstream string) error) {
+	m.caddyUpdater = fn
+}
+
+// SetDNSUpdater 注入 DNS 解析切换回调（DNS 层切换落地）。
+// 选线结果变化时，会把服务域名指向选中线路入口 IP。
+func (m *Manager) SetDNSUpdater(fn func(domain, ip string) error) {
+	m.dnsUpdater = fn
 }
 
 // Start 启动后台守护：立即执行一轮刷新与测速，之后按 interval 周期循环。
@@ -116,7 +137,108 @@ func (m *Manager) refresh(ctx context.Context) {
 	m.selector.ProbeAll(ctx)
 	sel := m.selector.Select()
 	m.saveHistory()
+	// 切换落地：选线结果同步到绑定的 Caddy 站点（域名层）与 DNS 解析（DNS 层）
+	m.applyCaddySwitch(sel.LineID)
+	m.applyDNSSwitch(sel.LineID)
 	m.log.Infof("[线路选择] 共 %d 条线路，当前线路: %q", len(lines), sel.LineID)
+}
+
+// applyCaddySwitch 将当前选中线路的入口地址同步到绑定了该线路的 Caddy 站点。
+// 通过 caddyUpdater 回调（main.go 注入）热加载 Caddy 反代目标，实现域名层自动切换。
+func (m *Manager) applyCaddySwitch(lineID string) {
+	if lineID == "" || m.caddyUpdater == nil {
+		return
+	}
+	// 找到选中线路的地址（作为 Caddy 反代目标入口）
+	var line selector.Line
+	for _, l := range m.selector.Lines() {
+		if l.ID == lineID {
+			line = l
+			break
+		}
+	}
+	if line.Address == "" {
+		return
+	}
+	// 查找绑定了 Caddy 站点且 LineRefs 包含该线路的服务
+	var services []model.TunService
+	if err := m.db.Where("caddy_site_id > ?", 0).Find(&services).Error; err != nil {
+		m.log.Warnf("[线路选择] 查询绑定 Caddy 的服务失败: %v", err)
+		return
+	}
+	for _, svc := range services {
+		var refs []string
+		if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err != nil {
+			continue
+		}
+		for _, ref := range refs {
+			if ref != lineID {
+				continue
+			}
+			if err := m.caddyUpdater(svc.CaddySiteID, line.Address); err != nil {
+				m.log.Warnf("[线路选择] 更新 Caddy 站点 %d 失败: %v", svc.CaddySiteID, err)
+			} else {
+				m.log.Infof("[线路选择] Caddy 站点 %d 反代目标已切换为 %s", svc.CaddySiteID, line.Address)
+			}
+			break
+		}
+	}
+}
+
+// applyDNSSwitch 将服务域名指向当前选中线路的入口 IP（DNS 层切换）。
+// 仅当服务配置了 Domain 且线路入口为 IP 时生效（域名入口走 Caddy 域名层）。
+// 通过 dnsUpdater 回调（main.go 注入 dnsmasq.SetRecord）写入自定义解析记录。
+func (m *Manager) applyDNSSwitch(lineID string) {
+	if lineID == "" || m.dnsUpdater == nil {
+		return
+	}
+	// 找到选中线路的地址，仅对 IP 入口做 DNS 切换
+	var line selector.Line
+	for _, l := range m.selector.Lines() {
+		if l.ID == lineID {
+			line = l
+			break
+		}
+	}
+	host := lineHost(line.Address)
+	if host == "" || net.ParseIP(host) == nil {
+		return
+	}
+	// 查找配置了 Domain 且 LineRefs 包含该线路的服务
+	var services []model.TunService
+	if err := m.db.Where("domain != ?", "").Find(&services).Error; err != nil {
+		m.log.Warnf("[线路选择] 查询配置域名服务失败: %v", err)
+		return
+	}
+	for _, svc := range services {
+		var refs []string
+		if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err != nil {
+			continue
+		}
+		for _, ref := range refs {
+			if ref != lineID {
+				continue
+			}
+			if err := m.dnsUpdater(svc.Domain, host); err != nil {
+				m.log.Warnf("[线路选择] 更新 DNS 解析 %s -> %s 失败: %v", svc.Domain, host, err)
+			} else {
+				m.log.Infof("[线路选择] DNS 解析 %s -> %s 已切换", svc.Domain, host)
+			}
+			break
+		}
+	}
+}
+
+// lineHost 从 host:port 地址中提取 host（无端口时视为纯 host）。
+func lineHost(address string) string {
+	if address == "" {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	return host
 }
 
 // maxHistoryPerLine 每条线路保留的探测历史上限

--- a/backend/service/linereg/linereg_test.go
+++ b/backend/service/linereg/linereg_test.go
@@ -439,6 +439,73 @@ func TestApplyCaddySwitchRollback(t *testing.T) {
 	}
 }
 
+// TestApplyPortSwitch 端口层切换：仅未绑定 Caddy/DNS 的服务触发重绑回调。
+func TestApplyPortSwitch(t *testing.T) {
+	db := newTestDB(t)
+	seedData(db)
+	// 端口层服务：无 Caddy 站点、无域名，关联 frp:1
+	portSvc := model.TunService{
+		Name:          "SSH 服务",
+		Enable:        true,
+		TargetAddress: "192.168.1.10",
+		TargetPort:    22,
+		Protocol:      "tcp",
+		LineRefs:      `["frp:1"]`,
+	}
+	db.Create(&portSvc)
+	// 域名层服务：绑定了 Caddy 站点，不应触发端口层重绑
+	db.Create(&model.TunService{
+		Name:          "Web 服务",
+		Enable:        true,
+		TargetAddress: "192.168.1.10",
+		TargetPort:    80,
+		Protocol:      "tcp",
+		LineRefs:      `["frp:1"]`,
+		CaddySiteID:   9,
+	})
+	// DNS 层服务：配置了域名，不应触发端口层重绑
+	db.Create(&model.TunService{
+		Name:          "带域名服务",
+		Enable:        true,
+		TargetAddress: "192.168.1.10",
+		TargetPort:    8080,
+		Protocol:      "tcp",
+		LineRefs:      `["frp:1"]`,
+		Domain:        "svc.example.com",
+	})
+
+	m := NewManager(db, nil, 0)
+	var calls []string
+	m.SetPortRebinder(func(svcID uint, lineID string) error {
+		calls = append(calls, fmt.Sprintf("%d:%s", svcID, lineID))
+		return nil
+	})
+
+	m.applyPortSwitch("frp:1")
+	if len(calls) != 1 || calls[0] != fmt.Sprintf("%d:frp:1", portSvc.ID) {
+		t.Fatalf("端口层重绑应只触发端口层服务 %d, got %v", portSvc.ID, calls)
+	}
+
+	// 未关联线路不触发
+	m.applyPortSwitch("easytier:1:0")
+	if len(calls) != 1 {
+		t.Fatalf("未关联线路不应触发重绑, got %d calls", len(calls))
+	}
+
+	// 重绑失败写入 last_error，成功清空
+	m.SetPortRebinder(func(svcID uint, lineID string) error {
+		return fmt.Errorf("模拟重绑失败")
+	})
+	m.applyPortSwitch("frp:1")
+	var got model.TunService
+	if err := db.First(&got, portSvc.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.LastError == "" {
+		t.Fatal("重绑失败应写入 last_error")
+	}
+}
+
 func TestLineHost(t *testing.T) {
 	cases := map[string]string{
 		"1.2.3.4:7000":                   "1.2.3.4",

--- a/backend/service/linereg/linereg_test.go
+++ b/backend/service/linereg/linereg_test.go
@@ -2,6 +2,7 @@ package linereg
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -387,6 +388,54 @@ func TestApplyDNSSwitchDomainEntrySkipped(t *testing.T) {
 	// 但该服务只关联 cftunnel:1，所以不应触发
 	if calls != 0 {
 		t.Fatalf("域名入口线路不应触发 DNS 切换, got %d calls", calls)
+	}
+}
+
+func TestApplyCaddySwitchRollback(t *testing.T) {
+	db := newTestDB(t)
+	seedData(db)
+	db.Create(&model.TunService{
+		Name:          "回滚测试服务",
+		Enable:        true,
+		TargetAddress: "127.0.0.1",
+		TargetPort:    8080,
+		LineRefs:      `["frp:1","nps:1"]`,
+		CaddySiteID:   9,
+	})
+
+	prober := &fakeProber{latencies: map[string]time.Duration{
+		"frp:1": 1 * time.Millisecond,
+	}}
+	m := NewManager(db, nil, 0)
+	m.selector = selector.NewSelector(prober, 0)
+
+	var applied []string
+	m.SetCaddyUpdater(func(siteID uint, upstream string) error {
+		// 模拟切换到 nps:1（5.6.7.8:8024）时 Caddy API 失败
+		if upstream == "5.6.7.8:8024" {
+			return fmt.Errorf("模拟 Caddy API 失败")
+		}
+		applied = append(applied, upstream)
+		return nil
+	})
+
+	// 第一次刷新：frp:1 延迟最低，成功切换到 1.2.3.4:7000
+	m.refresh(context.Background())
+	if len(applied) != 1 || applied[0] != "1.2.3.4:7000" {
+		t.Fatalf("第一次切换期望成功到 1.2.3.4:7000, got %v", applied)
+	}
+
+	// 第二次刷新：nps:1 延迟最低，切换 5.6.7.8:8024 失败，应回滚到上次成功的 1.2.3.4:7000
+	prober.latencies = map[string]time.Duration{
+		"nps:1": 1 * time.Millisecond,
+		"frp:1": 100 * time.Millisecond,
+	}
+	m.refresh(context.Background())
+	if len(applied) != 2 {
+		t.Fatalf("切换失败后应触发回滚调用, applied=%v", applied)
+	}
+	if applied[1] != "1.2.3.4:7000" {
+		t.Errorf("回滚应恢复到上次成功的 1.2.3.4:7000, got %q", applied[1])
 	}
 }
 

--- a/backend/service/linereg/linereg_test.go
+++ b/backend/service/linereg/linereg_test.go
@@ -30,6 +30,7 @@ func newTestDB(t *testing.T) *gorm.DB {
 		&model.WireguardPeer{},
 		&model.CftunnelConfig{},
 		&model.ProbeHistory{},
+		&model.TunService{},
 	); err != nil {
 		t.Fatalf("迁移失败: %v", err)
 	}
@@ -143,10 +144,19 @@ func TestBuildLinesNilDB(t *testing.T) {
 }
 
 // fakeProber 注入式探测器：全部返回固定延迟，用于验证 Manager 接线。
-type fakeProber struct{}
+type fakeProber struct {
+	latencies map[string]time.Duration
+}
 
 func (f *fakeProber) Probe(_ context.Context, line selector.Line) selector.ProbeResult {
-	return selector.ProbeResult{LineID: line.ID, TCPLatency: 10 * time.Millisecond}
+	lat := time.Duration(0)
+	if f.latencies != nil {
+		lat = f.latencies[line.ID]
+	}
+	if lat <= 0 {
+		lat = 10 * time.Millisecond
+	}
+	return selector.ProbeResult{LineID: line.ID, TCPLatency: lat}
 }
 
 func TestManagerRefreshWiresLines(t *testing.T) {
@@ -233,5 +243,163 @@ func TestRefreshPrunesHistory(t *testing.T) {
 	}
 	if count > maxHistoryPerLine {
 		t.Fatalf("历史超出上限: got %d, want <= %d", count, maxHistoryPerLine)
+	}
+}
+
+func TestApplyCaddySwitch(t *testing.T) {
+	db := newTestDB(t)
+	seedData(db)
+
+	// 创建绑定 Caddy 站点(站点 ID=9)且关联 cftunnel:1 线路的穿透服务
+	db.Create(&model.TunService{
+		Name:          "测试服务",
+		Enable:        true,
+		TargetAddress: "127.0.0.1",
+		TargetPort:    8080,
+		LineRefs:      `["frp:1","cftunnel:1"]`,
+		CaddySiteID:   9,
+	})
+
+	// 注入 Caddy 切换回调，记录调用
+	var gotSiteID uint
+	var gotUpstream string
+	var calls int
+	m := NewManager(db, nil, 0)
+	m.selector = selector.NewSelector(&fakeProber{latencies: map[string]time.Duration{
+		"frp:1": 1 * time.Millisecond,
+	}}, 0)
+	m.SetCaddyUpdater(func(siteID uint, upstream string) error {
+		calls++
+		gotSiteID = siteID
+		gotUpstream = upstream
+		return nil
+	})
+
+	m.refresh(context.Background())
+
+	// fakeProber 全部线路延迟相同，应选到第一条 frp:1
+	if calls == 0 {
+		t.Fatal("期望触发 Caddy 切换回调")
+	}
+	if gotSiteID != 9 {
+		t.Errorf("期望更新站点 9, got %d", gotSiteID)
+	}
+	if gotUpstream != "1.2.3.4:7000" {
+		t.Errorf("期望上游指向 frp:1 的地址 1.2.3.4:7000, got %q", gotUpstream)
+	}
+}
+
+func TestApplyCaddySwitchNoBinding(t *testing.T) {
+	db := newTestDB(t)
+	seedData(db)
+
+	// 服务未绑定 Caddy 站点（CaddySiteID=0），不应触发回调
+	db.Create(&model.TunService{
+		Name:          "无绑定服务",
+		Enable:        true,
+		TargetAddress: "127.0.0.1",
+		TargetPort:    8080,
+		LineRefs:      `["frp:1"]`,
+	})
+
+	calls := 0
+	m := NewManager(db, nil, 0)
+	m.selector = selector.NewSelector(&fakeProber{}, 0)
+	m.SetCaddyUpdater(func(siteID uint, upstream string) error {
+		calls++
+		return nil
+	})
+
+	m.refresh(context.Background())
+	if calls != 0 {
+		t.Fatalf("未绑定 Caddy 站点不应触发切换, got %d calls", calls)
+	}
+}
+
+func TestApplyDNSSwitch(t *testing.T) {
+	db := newTestDB(t)
+	seedData(db)
+
+	// 创建配置了 Domain 且关联 frp:1（入口 1.2.3.4:7000，IP 地址）的穿透服务
+	db.Create(&model.TunService{
+		Name:          "DNS 服务",
+		Enable:        true,
+		TargetAddress: "127.0.0.1",
+		TargetPort:    8080,
+		Domain:        "nas.example.com",
+		LineRefs:      `["frp:1","cftunnel:1"]`,
+	})
+
+	// 注入 DNS 切换回调，记录调用
+	var gotDomain, gotIP string
+	var calls int
+	m := NewManager(db, nil, 0)
+	m.selector = selector.NewSelector(&fakeProber{latencies: map[string]time.Duration{
+		"frp:1": 1 * time.Millisecond,
+	}}, 0)
+	m.SetDNSUpdater(func(domain, ip string) error {
+		calls++
+		gotDomain = domain
+		gotIP = ip
+		return nil
+	})
+
+	m.refresh(context.Background())
+
+	if calls == 0 {
+		t.Fatal("期望触发 DNS 切换回调")
+	}
+	if gotDomain != "nas.example.com" {
+		t.Errorf("期望域名 nas.example.com, got %q", gotDomain)
+	}
+	if gotIP != "1.2.3.4" {
+		t.Errorf("期望解析到 1.2.3.4（frp:1 入口 IP）, got %q", gotIP)
+	}
+}
+
+func TestApplyDNSSwitchDomainEntrySkipped(t *testing.T) {
+	db := newTestDB(t)
+	seedData(db)
+
+	// 服务配置了 Domain，但选中线路 cftunnel:1 是域名入口（cfargotunnel.com），
+	// 无 IP 可解析，不应触发 DNS 切换（域名层走 Caddy）
+	db.Create(&model.TunService{
+		Name:          "域名入口服务",
+		Enable:        true,
+		TargetAddress: "127.0.0.1",
+		TargetPort:    8080,
+		Domain:        "web.example.com",
+		LineRefs:      `["cftunnel:1"]`,
+	})
+
+	calls := 0
+	m := NewManager(db, nil, 0)
+	// 只给 frp:1 一条线路无法复现，这里直接构造：让 selector 选中 cftunnel:1
+	// 通过 fakeProber 全同延迟时会选到 cftunnel:1（seedData 中仅该服务关联它）
+	m.selector = selector.NewSelector(&fakeProber{}, 0)
+	m.SetDNSUpdater(func(domain, ip string) error {
+		calls++
+		return nil
+	})
+
+	m.refresh(context.Background())
+	// seedData 有 6 条线路，fakeProber 全同延迟，选中的是第一条（frp:1），
+	// 但该服务只关联 cftunnel:1，所以不应触发
+	if calls != 0 {
+		t.Fatalf("域名入口线路不应触发 DNS 切换, got %d calls", calls)
+	}
+}
+
+func TestLineHost(t *testing.T) {
+	cases := map[string]string{
+		"1.2.3.4:7000":                   "1.2.3.4",
+		"my-tunnel.cfargotunnel.com:443": "my-tunnel.cfargotunnel.com",
+		"plain-host":                     "plain-host",
+		"":                               "",
+	}
+	for in, want := range cases {
+		if got := lineHost(in); got != want {
+			t.Errorf("lineHost(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/backend/service/selector/README.md
+++ b/backend/service/selector/README.md
@@ -1,0 +1,101 @@
+# selector — 多工具穿透线路统一抽象 + 自动测速选线
+
+NetPanel 内置 frp / nps / easytier / wireguard 等多个穿透工具，各自维护自己的
+Manager。本包提供**线路层**的公共抽象：任何工具只要把它的可用线路描述为
+`[]Line`（地址 + 可选 HTTP 204 探测地址），就能接入统一的并发测速、自动选线
+（容差防抖）、手动锁线与后台守护。**零外部依赖**（仅标准库），可独立测试。
+
+## 线路模型
+
+```go
+type Line struct {
+    ID        string // 线路唯一标识（如 "frp:1" / "nps:2"）
+    Name      string // 展示名
+    Tool      string // 来源工具（frp / nps / easytier / wireguard / cloudflare…）
+    Layer     string // ""（端口层）或 "domain"（域名层，如 Cloudflare Tunnel）
+    Address   string // host:port，做 TCP 握手延迟测量
+    ProbeURL  string // 可选；非空时额外做一次 HTTP 204 出网探测
+}
+```
+
+- **端口层**（默认）：只做 TCP 握手延迟，最快、最普适。
+- **域名层**（`Layer: "domain"`）：`Address` 是域名层入口，未配置 `ProbeURL`
+  时自动探测 `https://<host>`。
+
+## 测速指标（ProbeResult）
+
+单条线路的一次测速返回两个延迟：
+
+| 字段 | 含义 |
+|---|---|
+| `TCPLatency`  | TCP 握手延迟（毫秒级，快速筛掉不通/高延迟线路） |
+| `HTTPLatency` | HTTP 204 出网探测延迟（仅配置了 `ProbeURL` 时非 0） |
+
+**排序使用 `effectiveLatency`**：配置了 `ProbeURL` 且 HTTP 探测成功时，**以
+HTTP 出网延迟为准**（它反映真实的出网可用性）；否则回退到 TCP 握手延迟。
+
+## 选线算法
+
+一次 `Select()` 的完整决策流程：
+
+```mermaid
+flowchart TD
+    A[Select] --> B{有手动锁线?}
+    B -- 是 --> C{锁线线路可用?}
+    C -- 是 --> D[返回锁线线路 Locked=true]
+    C -- 否 --> E[自动解除锁线]
+    B -- 否 --> E
+    E --> F[bestUsable: 可用线路中 effectiveLatency 最小者]
+    F --> G{存在可用线路?}
+    G -- 否 --> H[返回空 Selection]
+    G -- 是 --> I{当前线路仍可用 且<br/>lat(cur) - lat(best) ≤ tolerance?}
+    I -- 是 --> J[保持当前线路 不切换 防抖]
+    I -- 否 --> K[切换到 best]
+    J --> L[返回 Selection]
+    K --> L
+```
+
+### 三条核心规则
+
+1. **手动锁线优先**：`Lock(lineID)` 后完全跳过自动选线，除非被锁线路失效
+   （探测不可用且连续失败达阈值），此时自动解除锁并退回自动模式。
+2. **最快可用优先**：未锁线时，在**可用**线路中取 `effectiveLatency` 最小者。
+   可用 = 本次探测成功；或失败但连续失败次数未达 `failureThreshold` 且有最近
+   成功结果兜底。
+3. **容差防抖（hysteresis）**：当前线路仍可用且不比最优慢超过 `tolerance`
+   （默认 50ms）时**保持现状不切换**，避免两条相近线路上来回抖动。只有差距
+   超过容差（或当前线路失效）才真正切换。
+
+### 失败阈值（failureThreshold）
+
+- `SetFailureThreshold(n)`：连续失败达 n 次才判线路不可用（默认 1）。
+- 失败但未达阈值时，用**最近一次成功结果**的延迟参与排序（`latencyFor` 兜底），
+  避免瞬时抖动把延迟抬到异常高。
+- 无任何成功记录的线路始终视为不可用。
+
+### 后台守护建议
+
+`ProbeAll(ctx)` 并发探测全部线路（信号量限流 `SetMaxConcurrent`，默认 8），
+返回 `map[lineID]ProbeResult` 并更新连续失败计数与最近成功缓存。调用方通常
+用 goroutine + ticker 周期调用（如 60s），再调用 `Select()` 取当前选择；
+`Snapshot()` 提供线程安全的线路/选择/锁线状态快照供 UI 展示。
+
+## 并发安全
+
+`Selector` 内部用 `sync.Mutex` 保护全部状态；`ProbeAll` / `Select` / `Lock` /
+`Unlock` / `SetLines` / `Snapshot` 均可并发调用。`TCPProber.Probe` 本身并发安全。
+
+## 测试
+
+`selector_test.go` 通过**注入式 `Prober` 假实现**（`fakeProber`）模拟线路质量
+变化，不依赖真实网络，覆盖：
+
+- 选最快 / HTTP 延迟优先 / 跳过不可用 / 全部不可用
+- 容差防抖（相近线路不抖动、差距超容差才切换）
+- 手动锁线优先 / 锁线失效自动解除 / 未知锁线忽略
+- `SetLines` 清理过期结果与失效锁线 / 快照线程安全
+- 并发限流（信号量生效）
+- 失败阈值：瞬时失败保持线路、持续失败切换、恢复回到最快、无兜底记录判不可用
+- `domainHost` 解析
+
+运行：`cd backend && go test ./service/selector/... -v`

--- a/backend/service/tunservice/manager.go
+++ b/backend/service/tunservice/manager.go
@@ -119,6 +119,54 @@ func (m *Manager) Stop(id uint) {
 	}
 }
 
+// RebindPort 端口层切换落地：把服务关联的穿透规则重建到当前选中线路。
+//
+// 语义（先停后起，短暂抖动可接受）：
+//   - 停掉服务下「非选中线路」的运行中客户端，使端口映射只跟随当前线路；
+//   - 确保选中线路的客户端已运行（未运行时启动，运行中保持，避免无谓重启）。
+//
+// 仅服务处于启用状态时生效；由 linereg 在选线变化时调用。
+func (m *Manager) RebindPort(svcID uint, lineID string) error {
+	var svc model.TunService
+	if err := m.db.First(&svc, svcID).Error; err != nil {
+		return err
+	}
+	if !svc.Enable {
+		return nil
+	}
+	var refs []string
+	if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err != nil {
+		return nil
+	}
+	selected := false
+	for _, ref := range refs {
+		if ref == lineID {
+			selected = true
+			break
+		}
+	}
+	if !selected {
+		return nil
+	}
+	// 1) 停掉非选中线路的运行中客户端
+	for _, ref := range refs {
+		if ref != lineID && m.toolStatus(ref) == "running" {
+			m.stopLine(ref)
+			m.log.Infof("[穿透服务][%d] 停止非选中线路客户端 %s", svcID, ref)
+		}
+	}
+	// 2) 确保选中线路客户端运行（未运行才启动，避免每轮刷新无谓重启）
+	if m.toolStatus(lineID) == "running" {
+		return nil
+	}
+	if err := m.startLine(lineID); err != nil {
+		m.log.Errorf("[穿透服务][%d] 启动选中线路 %s 失败: %v", svcID, lineID, err)
+		return err
+	}
+	m.log.Infof("[穿透服务][%d] 端口层已重绑到线路 %s", svcID, lineID)
+	return nil
+}
+
 // History 返回服务关联线路的探测历史（按线路分组，每条线路取最近 limit 条）。
 func (m *Manager) History(id uint, limit int) (map[string][]model.ProbeHistory, error) {
 	svc, err := m.Get(id)

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -1865,6 +1865,18 @@ const en = {
       tip2: 'Support FRP, NPS, EasyTier, Cloudflare Tunnel, WireGuard',
       tip3: 'Auto config will establish tunnel connection when server comes online',
     },
+  // CF Tunnel
+  cftunnel: {
+    mode: 'Mode',
+    modeQuick: 'Quick (temporary tunnel)',
+    modeNamed: 'Named (named tunnel)',
+    modeToken: 'Token (remote config)',
+    localUrl: 'Local URL',
+    tunnelName: 'Tunnel Name',
+    credentialsFile: 'Credentials File',
+    configFile: 'Config File',
+    token: 'Token',
+    quickUrl: 'Quick URL',
   },
 }
 

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -466,6 +466,7 @@ const en = {
     modeQuick: 'Quick (Temporary Tunnel)',
     modeNamed: 'Named (Named Tunnel)',
     modeToken: 'Token (Remote Config)',
+    quickUrl: 'Quick URL',
     binaryNotFound: 'cloudflared binary not found',
     binaryPath: 'Binary Path',
     downloadBinary: 'Download cloudflared',
@@ -1865,18 +1866,6 @@ const en = {
       tip2: 'Support FRP, NPS, EasyTier, Cloudflare Tunnel, WireGuard',
       tip3: 'Auto config will establish tunnel connection when server comes online',
     },
-  // CF Tunnel
-  cftunnel: {
-    mode: 'Mode',
-    modeQuick: 'Quick (temporary tunnel)',
-    modeNamed: 'Named (named tunnel)',
-    modeToken: 'Token (remote config)',
-    localUrl: 'Local URL',
-    tunnelName: 'Tunnel Name',
-    credentialsFile: 'Credentials File',
-    configFile: 'Config File',
-    token: 'Token',
-    quickUrl: 'Quick URL',
   },
 }
 

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -1910,6 +1910,18 @@ const zh = {
       tip2: '支持 FRP、NPS、EasyTier、Cloudflare Tunnel、WireGuard',
       tip3: '自动配置功能会在服务器上线时自动建立隧道连接',
     },
+  // CF 隧道
+  cftunnel: {
+    mode: '模式',
+    modeQuick: 'Quick（临时隧道）',
+    modeNamed: 'Named（命名隧道）',
+    modeToken: 'Token（远程配置）',
+    localUrl: '本地服务地址',
+    tunnelName: '隧道名称',
+    credentialsFile: '凭据文件',
+    configFile: '配置文件',
+    token: 'Token',
+    quickUrl: 'Quick 入口',
   },
 }
 

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -474,6 +474,7 @@ const zh = {
     modeQuick: 'Quick（临时隧道）',
     modeNamed: 'Named（命名隧道）',
     modeToken: 'Token（远程配置）',
+    quickUrl: 'Quick 入口',
     binaryNotFound: 'cloudflared 二进制未找到',
     binaryPath: '二进制路径',
     downloadBinary: '下载 cloudflared',
@@ -1910,18 +1911,6 @@ const zh = {
       tip2: '支持 FRP、NPS、EasyTier、Cloudflare Tunnel、WireGuard',
       tip3: '自动配置功能会在服务器上线时自动建立隧道连接',
     },
-  // CF 隧道
-  cftunnel: {
-    mode: '模式',
-    modeQuick: 'Quick（临时隧道）',
-    modeNamed: 'Named（命名隧道）',
-    modeToken: 'Token（远程配置）',
-    localUrl: '本地服务地址',
-    tunnelName: '隧道名称',
-    credentialsFile: '凭据文件',
-    configFile: '配置文件',
-    token: 'Token',
-    quickUrl: 'Quick 入口',
   },
 }
 

--- a/webpage/src/pages/CfTunnel.tsx
+++ b/webpage/src/pages/CfTunnel.tsx
@@ -235,6 +235,19 @@ const CfTunnel: React.FC = () => {
             render: (v: string) => v || '-',
         },
         {
+            title: t('cftunnel.quickUrl'),
+            dataIndex: 'quick_url',
+            width: 240,
+            render: (v: string) =>
+                v ? (
+                    <Typography.Link href={v} target="_blank" rel="noreferrer">
+                        {v}
+                    </Typography.Link>
+                ) : (
+                    '-'
+                ),
+        },
+        {
             title: t('common.status'),
             dataIndex: 'status',
             width: 100,


### PR DESCRIPTION
## 概述 / Overview

本 PR 实现 issue #10 的两部分内容：

This PR implements both parts of issue #10:

**#10a Quick 隧道入口 / Quick tunnel entry**

- `CftunnelConfig` 新增 `QuickURL` 字段；启动 cloudflared 时用正则从 stdout 提取 `trycloudflare.com` 地址并落库，停止/退出时自动清理。
- 前端表格新增 Quick 入口列（可点击直达），并补全了原本缺失的 cftunnel i18n 段（zh/en）。

- Added `QuickURL` field to `CftunnelConfig`; on cloudflared start, the `trycloudflare.com` URL is extracted from stdout via regex and persisted, and cleaned up on stop/exit.
- Added a clickable Quick entry column to the frontend table and filled in the previously missing cftunnel i18n section (zh/en).

**#10b 端口层切换重绑 / Port-level switch rebinding**

- linereg 新增 `SetPortRebinder` / `applyPortSwitch`：筛选 `caddy_site_id=0` 且 `domain` 为空的纯 TCP/UDP 端口层服务，选线变化时触发重绑，失败写入 `LastError`。
- tunservice 新增 `RebindPort`：停掉非选中线路的运行中客户端、确保选中线路客户端运行（先停后起，短暂抖动可接受）。
- main.go 接线；新增单元测试 `TestApplyPortSwitch`。

- Added `SetPortRebinder` / `applyPortSwitch` in linereg: filters pure TCP/UDP port-level services (`caddy_site_id=0` and empty `domain`), rebinds on line-switch, and records failures in `LastError`.
- Added `RebindPort` in tunservice: stops clients running on non-selected lines and ensures the selected line's client is running (stop-then-start; brief downtime acceptable).
- Wired up in main.go; added unit test `TestApplyPortSwitch`.

## 变更 / Changes

- `feat(cftunnel)`: quick 隧道入口自动提取与前端展示（#10）
- `feat(selector)`: 端口层切换落地 — 选线变化时自动重绑 TCP/UDP 穿透规则（#10）

## 测试 / Testing

- 前端 dist 构建后，`go build ./...` / `go vet` / `go test ./...` 全部通过。

- With frontend dist built, `go build ./...` / `go vet` / `go test ./...` all pass.

## 依赖 / Dependencies

- 基于 PR #16（feat/switch-landing）分支叠放，请按依赖顺序合并：**#16 → #10**。

- Stacked on PR #16 (feat/switch-landing); please merge in dependency order: **#16 → #10**.

## 关联 / Related

- Closes #10
