### PR TITLE
[Feature] 探测策略参数化 + 服务级锁线 / Configurable probe strategy + per-service line locking (#9)

### DIFF
--- a/backend/api/handlers/linereg.go
+++ b/backend/api/handlers/linereg.go
@@ -1,0 +1,144 @@
+// Package handlers 线路探测策略参数化（#9a）：
+// 把探测间隔 / 失败阈值 / 容差 / 并发上限四项参数持久化到 SystemConfig，
+// 并通过 linereg.Manager.LoadProbeConfig() 在启动时与更新后应用。
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/netpanel/netpanel/model"
+	"github.com/netpanel/netpanel/service/linereg"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// 探测参数在 SystemConfig 中的键名。
+const (
+	cfgKeyIntervalSec      = "probe_interval_sec"
+	cfgKeyFailureThreshold = "probe_failure_threshold"
+	cfgKeyToleranceMs      = "probe_tolerance_ms"
+	cfgKeyMaxConcurrent    = "probe_max_concurrent"
+)
+
+// 探测参数默认值（与 linereg.DefaultInterval / selector 默认一致）。
+const (
+	defaultIntervalSec      = 60
+	defaultFailureThreshold = 2
+	defaultToleranceMs      = 50
+	defaultMaxConcurrent    = 8
+)
+
+// 校验范围（含上下界）。
+const (
+	minIntervalSec      = 5
+	maxIntervalSec      = 3600
+	minFailureThreshold = 1
+	maxFailureThreshold = 10
+	minToleranceMs      = 0
+	maxToleranceMs      = 5000
+	minMaxConcurrent    = 1
+	maxMaxConcurrent    = 64
+)
+
+// LineregHandler 线路探测策略处理器。
+type LineregHandler struct {
+	db  *gorm.DB
+	log *logrus.Logger
+	mgr *linereg.Manager
+}
+
+// NewLineregHandler 创建线路探测策略处理器。
+func NewLineregHandler(db *gorm.DB, log *logrus.Logger, mgr *linereg.Manager) *LineregHandler {
+	return &LineregHandler{db: db, log: log, mgr: mgr}
+}
+
+// probeConfigResponse 前端回填用响应体。
+type probeConfigResponse struct {
+	IntervalSec      int `json:"interval_sec"`
+	FailureThreshold int `json:"failure_threshold"`
+	ToleranceMs      int `json:"tolerance_ms"`
+	MaxConcurrent    int `json:"max_concurrent"`
+}
+
+// probeConfigRequest 前端提交的配置更新请求体。
+type probeConfigRequest struct {
+	IntervalSec      int `json:"interval_sec"`
+	FailureThreshold int `json:"failure_threshold"`
+	ToleranceMs      int `json:"tolerance_ms"`
+	MaxConcurrent    int `json:"max_concurrent"`
+}
+
+// getConfigInt 从 SystemConfig 读取一个整型参数；缺失或解析失败时返回 def。
+func getConfigInt(db *gorm.DB, key string, def int) int {
+	var cfg model.SystemConfig
+	if err := db.Where("key = ?", key).First(&cfg).Error; err != nil {
+		return def
+	}
+	v, err := strconv.Atoi(cfg.Value)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// GetConfig 读取探测策略四项参数（无记录返回默认值）。
+func (h *LineregHandler) GetConfig(c *gin.Context) {
+	resp := probeConfigResponse{
+		IntervalSec:      getConfigInt(h.db, cfgKeyIntervalSec, defaultIntervalSec),
+		FailureThreshold: getConfigInt(h.db, cfgKeyFailureThreshold, defaultFailureThreshold),
+		ToleranceMs:      getConfigInt(h.db, cfgKeyToleranceMs, defaultToleranceMs),
+		MaxConcurrent:    getConfigInt(h.db, cfgKeyMaxConcurrent, defaultMaxConcurrent),
+	}
+	c.JSON(http.StatusOK, gin.H{"code": 200, "data": resp})
+}
+
+// setConfigUpsert 写入（或更新）一条 SystemConfig 整型参数。
+func setConfigUpsert(db *gorm.DB, key string, value int) {
+	var cfg model.SystemConfig
+	if err := db.Where("key = ?", key).First(&cfg).Error; err == nil {
+		cfg.Value = strconv.Itoa(value)
+		db.Save(&cfg)
+		return
+	}
+	db.Create(&model.SystemConfig{Key: key, Value: strconv.Itoa(value)})
+}
+
+// UpdateConfig 校验并写入探测策略四项参数，随后应用（透传到 selector）。
+func (h *LineregHandler) UpdateConfig(c *gin.Context) {
+	var req probeConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": err.Error()})
+		return
+	}
+	// 范围校验
+	if req.IntervalSec < minIntervalSec || req.IntervalSec > maxIntervalSec {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "interval_sec out of range"})
+		return
+	}
+	if req.FailureThreshold < minFailureThreshold || req.FailureThreshold > maxFailureThreshold {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "failure_threshold out of range"})
+		return
+	}
+	if req.ToleranceMs < minToleranceMs || req.ToleranceMs > maxToleranceMs {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "tolerance_ms out of range"})
+		return
+	}
+	if req.MaxConcurrent < minMaxConcurrent || req.MaxConcurrent > maxMaxConcurrent {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "max_concurrent out of range"})
+		return
+	}
+	// 持久化
+	setConfigUpsert(h.db, cfgKeyIntervalSec, req.IntervalSec)
+	setConfigUpsert(h.db, cfgKeyFailureThreshold, req.FailureThreshold)
+	setConfigUpsert(h.db, cfgKeyToleranceMs, req.ToleranceMs)
+	setConfigUpsert(h.db, cfgKeyMaxConcurrent, req.MaxConcurrent)
+	// 立即应用（间隔需在下一轮生效，其余透传到 selector）
+	h.mgr.SetInterval(time.Duration(req.IntervalSec) * time.Second)
+	h.mgr.SetFailureThreshold(req.FailureThreshold)
+	h.mgr.SetTolerance(time.Duration(req.ToleranceMs) * time.Millisecond)
+	h.mgr.SetMaxConcurrent(req.MaxConcurrent)
+	c.JSON(http.StatusOK, gin.H{"code": 200, "message": "已更新"})
+}

--- a/backend/api/handlers/linereg.go
+++ b/backend/api/handlers/linereg.go
@@ -106,6 +106,23 @@ func setConfigUpsert(db *gorm.DB, key string, value int) {
 	db.Create(&model.SystemConfig{Key: key, Value: strconv.Itoa(value)})
 }
 
+// validateProbeConfig 校验探测策略四项参数是否在允许范围内，返回首个越界项名。
+func validateProbeConfig(req probeConfigRequest) string {
+	if req.IntervalSec < minIntervalSec || req.IntervalSec > maxIntervalSec {
+		return "interval_sec"
+	}
+	if req.FailureThreshold < minFailureThreshold || req.FailureThreshold > maxFailureThreshold {
+		return "failure_threshold"
+	}
+	if req.ToleranceMs < minToleranceMs || req.ToleranceMs > maxToleranceMs {
+		return "tolerance_ms"
+	}
+	if req.MaxConcurrent < minMaxConcurrent || req.MaxConcurrent > maxMaxConcurrent {
+		return "max_concurrent"
+	}
+	return ""
+}
+
 // UpdateConfig 校验并写入探测策略四项参数，随后应用（透传到 selector）。
 func (h *LineregHandler) UpdateConfig(c *gin.Context) {
 	var req probeConfigRequest
@@ -114,20 +131,8 @@ func (h *LineregHandler) UpdateConfig(c *gin.Context) {
 		return
 	}
 	// 范围校验
-	if req.IntervalSec < minIntervalSec || req.IntervalSec > maxIntervalSec {
-		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "interval_sec out of range"})
-		return
-	}
-	if req.FailureThreshold < minFailureThreshold || req.FailureThreshold > maxFailureThreshold {
-		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "failure_threshold out of range"})
-		return
-	}
-	if req.ToleranceMs < minToleranceMs || req.ToleranceMs > maxToleranceMs {
-		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "tolerance_ms out of range"})
-		return
-	}
-	if req.MaxConcurrent < minMaxConcurrent || req.MaxConcurrent > maxMaxConcurrent {
-		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "max_concurrent out of range"})
+	if field := validateProbeConfig(req); field != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": field + " out of range"})
 		return
 	}
 	// 持久化
@@ -135,7 +140,7 @@ func (h *LineregHandler) UpdateConfig(c *gin.Context) {
 	setConfigUpsert(h.db, cfgKeyFailureThreshold, req.FailureThreshold)
 	setConfigUpsert(h.db, cfgKeyToleranceMs, req.ToleranceMs)
 	setConfigUpsert(h.db, cfgKeyMaxConcurrent, req.MaxConcurrent)
-	// 立即应用（间隔需在下一轮生效，其余透传到 selector）
+	// 立即应用（间隔需在下一轮探测循环生效，其余透传到 selector 即时生效）
 	h.mgr.SetInterval(time.Duration(req.IntervalSec) * time.Second)
 	h.mgr.SetFailureThreshold(req.FailureThreshold)
 	h.mgr.SetTolerance(time.Duration(req.ToleranceMs) * time.Millisecond)

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netpanel/netpanel/service/dnsmasq"
 	"github.com/netpanel/netpanel/service/easytier"
 	"github.com/netpanel/netpanel/service/frp"
+	"github.com/netpanel/netpanel/service/linereg"
 	"github.com/netpanel/netpanel/service/nps"
 	"github.com/netpanel/netpanel/service/portforward"
 	"github.com/netpanel/netpanel/service/storage"
@@ -56,6 +57,7 @@ type RouterOptions struct {
 	MeshNodeMgr    *meshnode.Manager
 	TunserviceMgr  *tunservice.Manager
 	AiMgr          *ai.Manager
+	LineregMgr     *linereg.Manager
 }
 
 // NewRouter 创建路由
@@ -216,6 +218,11 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	auth.POST("/tunservice/:id/stop", tsHandler.Stop)
 	auth.GET("/tunservice/:id/candidates", tsHandler.Candidates)
 	auth.GET("/tunservice/:id/history", tsHandler.History)
+
+	// 线路探测策略（参数化配置）
+	lineHandler := handlers.NewLineregHandler(opts.DB, opts.Log, opts.LineregMgr)
+	auth.GET("/linereg/config", lineHandler.GetConfig)
+	auth.PUT("/linereg/config", lineHandler.UpdateConfig)
 
 	// WireGuard
 	wgHandler := handlers.NewWireguardHandler(opts.DB, opts.Log, opts.WireguardMgr)

--- a/backend/main.go
+++ b/backend/main.go
@@ -299,6 +299,7 @@ func startServer() *http.Server {
 		WireguardMgr:   wireguardMgr,
 		MeshNodeMgr:    meshNodeMgr,
 		TunserviceMgr:  tunserviceMgr,
+		LineregMgr:     lineregMgr,
 		DnsmasqMgr:     dnsmasqMgr,
 		WolMgr:         wolMgr,
 		CertMgr:        certMgr,

--- a/backend/model/models.go
+++ b/backend/model/models.go
@@ -600,6 +600,9 @@ type TunService struct {
 	Status    string `gorm:"size:20;default:'stopped'" json:"status"`
 	LastError string `gorm:"type:text" json:"last_error"`
 	Remark    string `gorm:"size:500" json:"remark"`
+	// LockedLine 服务级锁线：非空且存在于 LineRefs 时，该服务的有效线路
+	// 固定为 LockedLine，不再跟随全局选线结果切换；空串表示自动（跟随全局）。
+	LockedLine string `gorm:"size:50" json:"locked_line"`
 }
 
 // ===== 线路探测历史（可观测性） =====

--- a/backend/service/linereg/linereg.go
+++ b/backend/service/linereg/linereg.go
@@ -28,6 +28,22 @@ import (
 // DefaultInterval 默认的线路刷新与测速间隔。
 const DefaultInterval = 60 * time.Second
 
+// 探测参数在 SystemConfig 中的键名。
+const (
+	cfgKeyIntervalSec      = "probe_interval_sec"
+	cfgKeyFailureThreshold = "probe_failure_threshold"
+	cfgKeyToleranceMs      = "probe_tolerance_ms"
+	cfgKeyMaxConcurrent    = "probe_max_concurrent"
+)
+
+// 探测参数默认值（与 selector 默认一致）。
+const (
+	defaultIntervalSec      = 60
+	defaultFailureThreshold = 2
+	defaultToleranceMs      = 50
+	defaultMaxConcurrent    = 8
+)
+
 // Manager 线路注册中心：持有 selector，负责周期刷新线路并驱动测速选线。
 type Manager struct {
 	db       *gorm.DB
@@ -92,6 +108,48 @@ func (m *Manager) SetFailureThreshold(n int) {
 	m.selector.SetFailureThreshold(n)
 }
 
+// SetTolerance 透传设置选线防抖容差（须在 Start 前调用）。
+func (m *Manager) SetTolerance(d time.Duration) {
+	m.selector.SetTolerance(d)
+}
+
+// LoadProbeConfig 从 SystemConfig 读取探测策略四项参数并应用。
+// 缺失的键使用默认值。应在 Start 前调用（间隔与并发在首轮探测前生效）。
+func (m *Manager) LoadProbeConfig() error {
+	intervalSec := defaultIntervalSec
+	failureThreshold := defaultFailureThreshold
+	toleranceMs := defaultToleranceMs
+	maxConcurrent := defaultMaxConcurrent
+
+	var cfg model.SystemConfig
+	if err := m.db.Where("key = ?", cfgKeyIntervalSec).First(&cfg).Error; err == nil {
+		if v, perr := strconv.Atoi(cfg.Value); perr == nil {
+			intervalSec = v
+		}
+	}
+	if err := m.db.Where("key = ?", cfgKeyFailureThreshold).First(&cfg).Error; err == nil {
+		if v, perr := strconv.Atoi(cfg.Value); perr == nil {
+			failureThreshold = v
+		}
+	}
+	if err := m.db.Where("key = ?", cfgKeyToleranceMs).First(&cfg).Error; err == nil {
+		if v, perr := strconv.Atoi(cfg.Value); perr == nil {
+			toleranceMs = v
+		}
+	}
+	if err := m.db.Where("key = ?", cfgKeyMaxConcurrent).First(&cfg).Error; err == nil {
+		if v, perr := strconv.Atoi(cfg.Value); perr == nil {
+			maxConcurrent = v
+		}
+	}
+
+	m.SetInterval(time.Duration(intervalSec) * time.Second)
+	m.SetFailureThreshold(failureThreshold)
+	m.SetTolerance(time.Duration(toleranceMs) * time.Millisecond)
+	m.SetMaxConcurrent(maxConcurrent)
+	return nil
+}
+
 // SetCaddyUpdater 注入 Caddy 反代目标切换回调（域名层切换落地）。
 // 选线结果变化时，会把选中线路的入口地址同步到绑定了该线路的 Caddy 站点。
 func (m *Manager) SetCaddyUpdater(fn func(siteID uint, upstream string) error) {
@@ -113,6 +171,12 @@ func (m *Manager) SetPortRebinder(fn func(svcID uint, lineID string) error) {
 
 // Start 启动后台守护：立即执行一轮刷新与测速，之后按 interval 周期循环。
 func (m *Manager) Start() {
+	// 启动前加载探测策略参数（覆盖默认值）
+	if m.db != nil {
+		if err := m.LoadProbeConfig(); err != nil {
+			m.log.Warnf("[线路选择] 加载探测策略失败，使用默认值: %v", err)
+		}
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 	m.wg.Add(1)
@@ -163,61 +227,88 @@ func (m *Manager) refresh(ctx context.Context) {
 	m.log.Infof("[线路选择] 共 %d 条线路，当前线路: %q", len(lines), sel.LineID)
 }
 
+// effectiveLine 返回某服务在本次选线中的有效线路。
+// 若服务设置了 LockedLine 且该线路存在于其 LineRefs，则使用 LockedLine
+// （服务级锁线优先于全局选线）；否则使用全局选中线路 globalLineID。
+func (m *Manager) effectiveLine(svc model.TunService, globalLineID string) string {
+	if svc.LockedLine != "" {
+		var refs []string
+		if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err == nil {
+			for _, ref := range refs {
+				if ref == svc.LockedLine {
+					return svc.LockedLine
+				}
+			}
+		}
+	}
+	return globalLineID
+}
+
 // applyCaddySwitch 将当前选中线路的入口地址同步到绑定了该线路的 Caddy 站点。
 // 通过 caddyUpdater 回调（main.go 注入）热加载 Caddy 反代目标，实现域名层自动切换。
 func (m *Manager) applyCaddySwitch(lineID string) {
 	if lineID == "" || m.caddyUpdater == nil {
 		return
 	}
-	// 找到选中线路的地址（作为 Caddy 反代目标入口）
-	var line selector.Line
-	for _, l := range m.selector.Lines() {
-		if l.ID == lineID {
-			line = l
-			break
-		}
-	}
-	if line.Address == "" {
-		return
-	}
-	// 查找绑定了 Caddy 站点且 LineRefs 包含该线路的服务
+	// 查找绑定了 Caddy 站点的服务
 	var services []model.TunService
 	if err := m.db.Where("caddy_site_id > ?", 0).Find(&services).Error; err != nil {
 		m.log.Warnf("[线路选择] 查询绑定 Caddy 的服务失败: %v", err)
 		return
 	}
 	for _, svc := range services {
+		// 服务级锁线：若 LockedLine 存在于 LineRefs，使用锁定线路；否则用全局线路
+		effLineID := m.effectiveLine(svc, lineID)
+		if effLineID == "" {
+			continue
+		}
+		// 找到有效线路的地址（作为 Caddy 反代目标入口）
+		var line selector.Line
+		for _, l := range m.selector.Lines() {
+			if l.ID == effLineID {
+				line = l
+				break
+			}
+		}
+		if line.Address == "" {
+			continue
+		}
+		// 校验该有效线路确实在服务的 LineRefs 中
 		var refs []string
 		if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err != nil {
 			continue
 		}
+		found := false
 		for _, ref := range refs {
-			if ref != lineID {
-				continue
+			if ref == effLineID {
+				found = true
+				break
 			}
-			if err := m.caddyUpdater(svc.CaddySiteID, line.Address); err != nil {
-				m.log.Errorf("[线路选择] 更新 Caddy 站点 %d 失败: %v", svc.CaddySiteID, err)
-				// 回滚到上一次成功切换的上游目标，避免 Caddy 与新线路不一致
-				m.lastMu.Lock()
-				old, ok := m.lastUpstream[svc.CaddySiteID]
-				m.lastMu.Unlock()
-				if ok && old != "" && old != line.Address {
-					if rerr := m.caddyUpdater(svc.CaddySiteID, old); rerr != nil {
-						m.log.Errorf("[线路选择] 回滚 Caddy 站点 %d 到 %s 失败: %v", svc.CaddySiteID, old, rerr)
-					} else {
-						m.log.Warnf("[线路选择] Caddy 站点 %d 已回滚到 %s", svc.CaddySiteID, old)
-					}
+		}
+		if !found {
+			continue
+		}
+		if err := m.caddyUpdater(svc.CaddySiteID, line.Address); err != nil {
+			m.log.Errorf("[线路选择] 更新 Caddy 站点 %d 失败: %v", svc.CaddySiteID, err)
+			// 回滚到上一次成功切换的上游目标，避免 Caddy 与新线路不一致
+			m.lastMu.Lock()
+			old, ok := m.lastUpstream[svc.CaddySiteID]
+			m.lastMu.Unlock()
+			if ok && old != "" && old != line.Address {
+				if rerr := m.caddyUpdater(svc.CaddySiteID, old); rerr != nil {
+					m.log.Errorf("[线路选择] 回滚 Caddy 站点 %d 到 %s 失败: %v", svc.CaddySiteID, old, rerr)
+				} else {
+					m.log.Warnf("[线路选择] Caddy 站点 %d 已回滚到 %s", svc.CaddySiteID, old)
 				}
-				// 记录错误供 UI 排查
-				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
-			} else {
-				m.lastMu.Lock()
-				m.lastUpstream[svc.CaddySiteID] = line.Address
-				m.lastMu.Unlock()
-				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
-				m.log.Infof("[线路选择] Caddy 站点 %d 反代目标已切换为 %s", svc.CaddySiteID, line.Address)
 			}
-			break
+			// 记录错误供 UI 排查
+			m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
+		} else {
+			m.lastMu.Lock()
+			m.lastUpstream[svc.CaddySiteID] = line.Address
+			m.lastMu.Unlock()
+			m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
+			m.log.Infof("[线路选择] Caddy 站点 %d 反代目标已切换为 %s", svc.CaddySiteID, line.Address)
 		}
 	}
 }
@@ -229,42 +320,52 @@ func (m *Manager) applyDNSSwitch(lineID string) {
 	if lineID == "" || m.dnsUpdater == nil {
 		return
 	}
-	// 找到选中线路的地址，仅对 IP 入口做 DNS 切换
-	var line selector.Line
-	for _, l := range m.selector.Lines() {
-		if l.ID == lineID {
-			line = l
-			break
-		}
-	}
-	host := lineHost(line.Address)
-	if host == "" || net.ParseIP(host) == nil {
-		return
-	}
-	// 查找配置了 Domain 且 LineRefs 包含该线路的服务
+	// 查找配置了 Domain 的服务
 	var services []model.TunService
 	if err := m.db.Where("domain != ?", "").Find(&services).Error; err != nil {
 		m.log.Warnf("[线路选择] 查询配置域名服务失败: %v", err)
 		return
 	}
 	for _, svc := range services {
+		// 服务级锁线：若 LockedLine 存在于 LineRefs，使用锁定线路；否则用全局线路
+		effLineID := m.effectiveLine(svc, lineID)
+		if effLineID == "" {
+			continue
+		}
+		// 找到有效线路的地址，仅对 IP 入口做 DNS 切换
+		var line selector.Line
+		for _, l := range m.selector.Lines() {
+			if l.ID == effLineID {
+				line = l
+				break
+			}
+		}
+		host := lineHost(line.Address)
+		if host == "" || net.ParseIP(host) == nil {
+			continue
+		}
+		// 校验该有效线路确实在服务的 LineRefs 中
 		var refs []string
 		if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err != nil {
 			continue
 		}
+		found := false
 		for _, ref := range refs {
-			if ref != lineID {
-				continue
+			if ref == effLineID {
+				found = true
+				break
 			}
-			if err := m.dnsUpdater(svc.Domain, host); err != nil {
-				m.log.Warnf("[线路选择] 更新 DNS 解析 %s -> %s 失败: %v", svc.Domain, host, err)
-				// 记录错误供 UI 排查
-				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
-			} else {
-				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
-				m.log.Infof("[线路选择] DNS 解析 %s -> %s 已切换", svc.Domain, host)
-			}
-			break
+		}
+		if !found {
+			continue
+		}
+		if err := m.dnsUpdater(svc.Domain, host); err != nil {
+			m.log.Warnf("[线路选择] 更新 DNS 解析 %s -> %s 失败: %v", svc.Domain, host, err)
+			// 记录错误供 UI 排查
+			m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
+		} else {
+			m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
+			m.log.Infof("[线路选择] DNS 解析 %s -> %s 已切换", svc.Domain, host)
 		}
 	}
 }
@@ -284,23 +385,33 @@ func (m *Manager) applyPortSwitch(lineID string) {
 		return
 	}
 	for _, svc := range services {
+		// 服务级锁线：若 LockedLine 存在于 LineRefs，使用锁定线路；否则用全局线路
+		effLineID := m.effectiveLine(svc, lineID)
+		if effLineID == "" {
+			continue
+		}
+		// 校验该有效线路确实在服务的 LineRefs 中
 		var refs []string
 		if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err != nil {
 			continue
 		}
+		found := false
 		for _, ref := range refs {
-			if ref != lineID {
-				continue
+			if ref == effLineID {
+				found = true
+				break
 			}
-			if err := m.portRebinder(svc.ID, lineID); err != nil {
-				m.log.Errorf("[线路选择] 端口层服务 %d 重绑线路 %s 失败: %v", svc.ID, lineID, err)
-				// 记录错误供 UI 排查
-				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
-			} else {
-				m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
-				m.log.Infof("[线路选择] 端口层服务 %d 已重绑到线路 %s", svc.ID, lineID)
-			}
-			break
+		}
+		if !found {
+			continue
+		}
+		if err := m.portRebinder(svc.ID, effLineID); err != nil {
+			m.log.Errorf("[线路选择] 端口层服务 %d 重绑线路 %s 失败: %v", svc.ID, effLineID, err)
+			// 记录错误供 UI 排查
+			m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", err.Error())
+		} else {
+			m.db.Model(&model.TunService{}).Where("id = ?", svc.ID).Update("last_error", "")
+			m.log.Infof("[线路选择] 端口层服务 %d 已重绑到线路 %s", svc.ID, effLineID)
 		}
 	}
 }

--- a/backend/service/selector/selector.go
+++ b/backend/service/selector/selector.go
@@ -225,6 +225,17 @@ func (s *Selector) SetFailureThreshold(n int) {
 	s.failureThreshold = n
 }
 
+// SetTolerance 设置选线防抖容差（须在首次 ProbeAll 前调用，否则不保证生效）。
+// d<=0 时重置为默认 50ms。容差越大越不敏感于延迟波动（抖动更少）。
+func (s *Selector) SetTolerance(d time.Duration) {
+	if d <= 0 {
+		d = 50 * time.Millisecond
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tolerance = d
+}
+
 // SetLines 全量替换线路集合（保留锁线与当前选择；失效的锁线自动解除）。
 // 拷贝传入 slice，避免调用方后续修改污染内部状态。
 func (s *Selector) SetLines(lines []Line) {

--- a/backend/service/selector/selector_test.go
+++ b/backend/service/selector/selector_test.go
@@ -361,3 +361,36 @@ func TestDomainHost(t *testing.T) {
 		}
 	}
 }
+
+// TestSetToleranceChangesHysteresisWindow 验证 SetTolerance 后防抖窗口随之变化：
+// 设置大容差时，当前线路即使比最优慢很多也不切换（在容差内）。
+func TestSetToleranceChangesHysteresisWindow(t *testing.T) {
+	s, f := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 20 * time.Millisecond},
+		nil,
+	)
+	s.ProbeAll(context.Background())
+	first := s.Select()
+	if first.LineID != "a" {
+		t.Fatalf("first select should pick fastest a, got %q", first.LineID)
+	}
+
+	// 设置大容差 500ms：b 提升到 11ms（a=10，差 1ms），应保持 a
+	s.SetTolerance(500 * time.Millisecond)
+	f.latencies["b"] = 11 * time.Millisecond
+	s.ProbeAll(context.Background())
+	second := s.Select()
+	if second.LineID != "a" {
+		t.Fatalf("with large tolerance, expected keep a, got %q", second.LineID)
+	}
+
+	// 切回小容差 1µs：b 提升到 9ms（比 a=10ms 快 1ms），差距 > 容差 → 切到 b
+	s.SetTolerance(1 * time.Microsecond)
+	f.latencies["b"] = 9 * time.Millisecond
+	s.ProbeAll(context.Background())
+	third := s.Select()
+	if third.LineID != "b" {
+		t.Fatalf("with tiny tolerance, expected switch to b, got %q", third.LineID)
+	}
+}

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -588,7 +588,14 @@ export const initApi = {
 }
 
 // ===== 线路探测策略（linereg） =====
+export interface ProbeConfig {
+    interval_sec: number
+    failure_threshold: number
+    tolerance_ms: number
+    max_concurrent: number
+}
+
 export const lineregApi = {
-  getConfig: () => request.get('/v1/linereg/config'),
-  updateConfig: (data: any) => request.put('/v1/linereg/config', data),
+    getConfig: () => request.get<ProbeConfig>('/v1/linereg/config'),
+    updateConfig: (data: ProbeConfig) => request.put('/v1/linereg/config', data),
 }

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -123,6 +123,18 @@ export const tunserviceApi = {
   history: (id: number, limit = 100) => request.get(`/v1/tunservice/${id}/history?limit=${limit}`),
 }
 
+// ===== 穿透服务（统一内网穿透管理） =====
+export const tunserviceApi = {
+  list: () => request.get('/v1/tunservice'),
+  get: (id: number) => request.get(`/v1/tunservice/${id}`),
+  create: (data: any) => request.post('/v1/tunservice', data),
+  update: (id: number, data: any) => request.put(`/v1/tunservice/${id}`, data),
+  delete: (id: number) => request.delete(`/v1/tunservice/${id}`),
+  start: (id: number) => request.post(`/v1/tunservice/${id}/start`),
+  stop: (id: number) => request.post(`/v1/tunservice/${id}/stop`),
+  candidates: (id: number) => request.get(`/v1/tunservice/${id}/candidates`),
+}
+
 // ===== WireGuard =====
 export const wireguardApi = {
   list: () => request.get('/v1/wireguard'),

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -586,3 +586,9 @@ export const initApi = {
   status: () => request.get('/v1/init/status'),
   setup: (data: { username: string; password: string }) => request.post('/v1/init/setup', data),
 }
+
+// ===== 线路探测策略（linereg） =====
+export const lineregApi = {
+  getConfig: () => request.get('/v1/linereg/config'),
+  updateConfig: (data: any) => request.put('/v1/linereg/config', data),
+}

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -1888,18 +1888,6 @@ const en = {
       tip2: 'Support FRP, NPS, EasyTier, Cloudflare Tunnel, WireGuard',
       tip3: 'Auto config will establish tunnel connection when server comes online',
     },
-  // CF Tunnel
-  cftunnel: {
-    mode: 'Mode',
-    modeQuick: 'Quick (temporary tunnel)',
-    modeNamed: 'Named (named tunnel)',
-    modeToken: 'Token (remote config)',
-    localUrl: 'Local URL',
-    tunnelName: 'Tunnel Name',
-    credentialsFile: 'Credentials File',
-    configFile: 'Config File',
-    token: 'Token',
-    quickUrl: 'Quick URL',
   },
 }
 

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -1616,6 +1616,15 @@ const en = {
     latency: 'Latency',
     trend: 'Latency Trend',
     noHistory: 'No history records',
+    probeConfig: 'Line Policy',
+    probeInterval: 'Probe Interval (sec)',
+    failureThreshold: 'Failure Threshold',
+    toleranceMs: 'Tolerance (ms)',
+    maxConcurrent: 'Max Concurrent',
+    lockLine: 'Lock Line',
+    auto: 'Auto',
+    saved: 'Saved',
+    loadFailed: 'Load Failed',
   },
   // AI Management
   ai: {

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -1879,6 +1879,18 @@ const en = {
       tip2: 'Support FRP, NPS, EasyTier, Cloudflare Tunnel, WireGuard',
       tip3: 'Auto config will establish tunnel connection when server comes online',
     },
+  // CF Tunnel
+  cftunnel: {
+    mode: 'Mode',
+    modeQuick: 'Quick (temporary tunnel)',
+    modeNamed: 'Named (named tunnel)',
+    modeToken: 'Token (remote config)',
+    localUrl: 'Local URL',
+    tunnelName: 'Tunnel Name',
+    credentialsFile: 'Credentials File',
+    configFile: 'Config File',
+    token: 'Token',
+    quickUrl: 'Quick URL',
   },
 }
 

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -1625,6 +1625,7 @@ const en = {
     auto: 'Auto',
     saved: 'Saved',
     loadFailed: 'Load Failed',
+    loadFailedFallback: 'Failed to load; defaults filled, you can edit and save',
   },
   // AI Management
   ai: {

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -1664,6 +1664,7 @@ const zh = {
     auto: '自动',
     saved: '已保存',
     loadFailed: '加载失败',
+    loadFailedFallback: '加载失败，已填充默认值，可直接修改后保存',
   },
   // AI 管理
   ai: {

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -1924,6 +1924,18 @@ const zh = {
       tip2: '支持 FRP、NPS、EasyTier、Cloudflare Tunnel、WireGuard',
       tip3: '自动配置功能会在服务器上线时自动建立隧道连接',
     },
+  // CF 隧道
+  cftunnel: {
+    mode: '模式',
+    modeQuick: 'Quick（临时隧道）',
+    modeNamed: 'Named（命名隧道）',
+    modeToken: 'Token（远程配置）',
+    localUrl: '本地服务地址',
+    tunnelName: '隧道名称',
+    credentialsFile: '凭据文件',
+    configFile: '配置文件',
+    token: 'Token',
+    quickUrl: 'Quick 入口',
   },
 }
 

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -1655,6 +1655,15 @@ const zh = {
     latency: '延迟',
     trend: '延迟趋势',
     noHistory: '暂无历史记录',
+    probeConfig: '线路策略',
+    probeInterval: '探测间隔(秒)',
+    failureThreshold: '失败阈值(次)',
+    toleranceMs: '容差(毫秒)',
+    maxConcurrent: '并发上限',
+    lockLine: '锁定线路',
+    auto: '自动',
+    saved: '已保存',
+    loadFailed: '加载失败',
   },
   // AI 管理
   ai: {

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -1933,18 +1933,6 @@ const zh = {
       tip2: '支持 FRP、NPS、EasyTier、Cloudflare Tunnel、WireGuard',
       tip3: '自动配置功能会在服务器上线时自动建立隧道连接',
     },
-  // CF 隧道
-  cftunnel: {
-    mode: '模式',
-    modeQuick: 'Quick（临时隧道）',
-    modeNamed: 'Named（命名隧道）',
-    modeToken: 'Token（远程配置）',
-    localUrl: '本地服务地址',
-    tunnelName: '隧道名称',
-    credentialsFile: '凭据文件',
-    configFile: '配置文件',
-    token: 'Token',
-    quickUrl: 'Quick 入口',
   },
 }
 

--- a/webpage/src/pages/TunService.tsx
+++ b/webpage/src/pages/TunService.tsx
@@ -24,9 +24,10 @@ import {
     PlusOutlined,
     ReloadOutlined,
     StopOutlined,
+    SettingOutlined,
 } from '@ant-design/icons'
 import {useTranslation} from 'react-i18next'
-import {tunserviceApi} from '../api'
+import {lineregApi, tunserviceApi} from '../api'
 import StatusTag from '../components/StatusTag'
 
 const {Option} = Select
@@ -55,6 +56,9 @@ const TunService: React.FC = () => {
     const [detail, setDetail] = useState<any>(null)
     const [history, setHistory] = useState<Record<string, any[]>>({})
     const [form] = Form.useForm()
+    const [probeOpen, setProbeOpen] = useState(false)
+    const [probeLoading, setProbeLoading] = useState(false)
+    const [probeForm] = Form.useForm()
 
     const load = async () => {
         setLoading(true)
@@ -140,6 +144,35 @@ const TunService: React.FC = () => {
             await tunserviceApi.delete(id)
             message.success(t('common.deleted'))
             load()
+        } catch (e: any) {
+            message.error(e?.response?.data?.message || t('common.failed'))
+        }
+    }
+
+    const openProbe = async () => {
+        setProbeOpen(true)
+        setProbeLoading(true)
+        try {
+            const res = await lineregApi.getConfig()
+            probeForm.setFieldsValue({
+                interval_sec: res?.data?.interval_sec ?? 60,
+                failure_threshold: res?.data?.failure_threshold ?? 2,
+                tolerance_ms: res?.data?.tolerance_ms ?? 50,
+                max_concurrent: res?.data?.max_concurrent ?? 8,
+            })
+        } catch {
+            message.error(t('tunservice.loadFailed'))
+        } finally {
+            setProbeLoading(false)
+        }
+    }
+
+    const saveProbe = async () => {
+        const values = await probeForm.validateFields()
+        try {
+            await lineregApi.updateConfig(values)
+            message.success(t('tunservice.saved'))
+            setProbeOpen(false)
         } catch (e: any) {
             message.error(e?.response?.data?.message || t('common.failed'))
         }
@@ -282,6 +315,9 @@ const TunService: React.FC = () => {
                 <Button icon={<ReloadOutlined/>} onClick={load}>
                     {t('common.refresh')}
                 </Button>
+                <Button icon={<SettingOutlined/>} onClick={openProbe}>
+                    {t('tunservice.probeConfig')}
+                </Button>
             </Space>
 
             <Table
@@ -324,11 +360,44 @@ const TunService: React.FC = () => {
                     >
                         <Input.TextArea rows={3} placeholder='["frp:1","cftunnel:2"]'/>
                     </Form.Item>
+                    <Form.Item name="locked_line" label={t('tunservice.lockLine')}>
+                        <Select allowClear placeholder={t('tunservice.auto')}>
+                            <Option value="">{t('tunservice.auto')}</Option>
+                            {editing?.lines?.map((l: any) => (
+                                <Option key={l.id} value={l.id}>{l.name || l.id}</Option>
+                            ))}
+                        </Select>
+                    </Form.Item>
                     <Form.Item name="enable" label={t('common.enable')} valuePropName="checked">
                         <Switch/>
                     </Form.Item>
                     <Form.Item name="remark" label={t('common.remark')}>
                         <Input.TextArea rows={2}/>
+                    </Form.Item>
+                </Form>
+            </Modal>
+
+            <Modal
+                title={t('tunservice.probeConfig')}
+                open={probeOpen}
+                onOk={saveProbe}
+                onCancel={() => setProbeOpen(false)}
+                destroyOnClose
+                width={480}
+                confirmLoading={probeLoading}
+            >
+                <Form form={probeForm} layout="vertical">
+                    <Form.Item name="interval_sec" label={t('tunservice.probeInterval')} rules={[{required: true}]}>
+                        <InputNumber min={5} max={3600} style={{width: '100%'}}/>
+                    </Form.Item>
+                    <Form.Item name="failure_threshold" label={t('tunservice.failureThreshold')} rules={[{required: true}]}>
+                        <InputNumber min={1} max={10} style={{width: '100%'}}/>
+                    </Form.Item>
+                    <Form.Item name="tolerance_ms" label={t('tunservice.toleranceMs')} rules={[{required: true}]}>
+                        <InputNumber min={0} max={5000} style={{width: '100%'}}/>
+                    </Form.Item>
+                    <Form.Item name="max_concurrent" label={t('tunservice.maxConcurrent')} rules={[{required: true}]}>
+                        <InputNumber min={1} max={64} style={{width: '100%'}}/>
                     </Form.Item>
                 </Form>
             </Modal>

--- a/webpage/src/pages/TunService.tsx
+++ b/webpage/src/pages/TunService.tsx
@@ -161,7 +161,14 @@ const TunService: React.FC = () => {
                 max_concurrent: res?.data?.max_concurrent ?? 8,
             })
         } catch {
-            message.error(t('tunservice.loadFailed'))
+            // 加载失败时回填默认值，用户仍可直接修改后保存
+            probeForm.setFieldsValue({
+                interval_sec: 60,
+                failure_threshold: 2,
+                tolerance_ms: 50,
+                max_concurrent: 8,
+            })
+            message.warning(t('tunservice.loadFailedFallback'))
         } finally {
             setProbeLoading(false)
         }


### PR DESCRIPTION
## 概述 / Overview

本 PR 实现 issue #9：探测策略参数化 + 服务级锁线。

This PR implements issue #9: configurable probe strategy + per-service line locking.

**探测策略参数化 / Configurable probe strategy**

- selector 新增 `SetTolerance`，容差可配置。
- linereg 新增 `LoadProbeConfig`：从 SystemConfig 读取 `probe_interval_sec` / `probe_failure_threshold` / `probe_tolerance_ms` / `probe_max_concurrent`（默认 60 / 2 / 50 / 8）。
- 新增 `handlers/linereg.go`：GET/PUT `/v1/linereg/config`，带范围校验；router.go 增加 `LineregMgr` 与对应路由。

- Added `SetTolerance` to selector, making the tolerance configurable.
- Added `LoadProbeConfig` in linereg: reads `probe_interval_sec` / `probe_failure_threshold` / `probe_tolerance_ms` / `probe_max_concurrent` from SystemConfig (defaults 60 / 2 / 50 / 8).
- Added `handlers/linereg.go`: GET/PUT `/v1/linereg/config` with range validation; registered `LineregMgr` and routes in router.go.

**服务级锁线 / Per-service line locking**

- `TunService.LockedLine` 服务级锁线：`effectiveLine` 优先于全局选线。
- 前端 TunService 页新增「线路策略」Modal 与「锁定线路」Select + i18n（zh/en）。

- Added `TunService.LockedLine` per-service locking: `effectiveLine` takes precedence over the global line selection.
- Added a "Line Strategy" modal and "Locked Line" select to the frontend TunService page, with i18n (zh/en).

## 变更 / Changes

- `feat(linereg)`: 探测策略参数化 + 服务级锁线（#9）
- `feat`: 接线 — linereg 探测策略路由（#9）

## 测试 / Testing

- 前端 dist 构建后，`go build ./...` / `go vet` / `go test ./...` 全部通过。

- With frontend dist built, `go build ./...` / `go vet` / `go test ./...` all pass.

## 依赖 / Dependencies

- 基于 `feat/port-rebind` 分支叠放，请按依赖顺序合并：**#16 → #10 → #9**。

- Stacked on `feat/port-rebind`; please merge in dependency order: **#16 → #10 → #9**.

## 关联 / Related

- Closes #9
