### PR TITLE
[Fix] 修复 cert/wireguard 非恒定格式字符串 / Fix non-constant format strings in cert/wireguard

### DIFF
--- a/backend/service/cert/manager.go
+++ b/backend/service/cert/manager.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -525,7 +526,7 @@ func (m *Manager) StepObtain(id uint) error {
 				}
 			}
 		}
-		return m.setError(id, fmt.Errorf(errMsg))
+		return m.setError(id, errors.New(errMsg))
 	}
 
 	if order.Status != "ready" && order.Status != "valid" {

--- a/backend/service/wireguard/manager.go
+++ b/backend/service/wireguard/manager.go
@@ -3,6 +3,7 @@ package wireguard
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -140,7 +141,7 @@ func (m *Manager) Start(id uint) error {
 			"status":     "error",
 			"last_error": errMsg,
 		})
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	m.running.Store(id, true)


### PR DESCRIPTION
## 概述 / Overview

小修：修复 cert 与 wireguard 模块中非恒定格式字符串导致的 `go vet` 报错。

Minor fix: resolve `go vet` errors caused by non-constant format strings in the cert and wireguard packages.

- 将运行时拼接的日志格式改为恒定格式字符串 + 参数传递，消除 vet 告警，行为不变。

- Changed runtime-constructed log format strings to constant format strings with arguments, eliminating the vet warnings without changing behavior.

## 变更 / Changes

- `fix`: cert/wireguard 非恒定格式字符串 vet 报错

## 测试 / Testing

- 前端 dist 构建后，`go build ./...` / `go vet` / `go test ./...` 全部通过。

- With frontend dist built, `go build ./...` / `go vet` / `go test ./...` all pass.

## 依赖 / Dependencies

- 独立小 PR，无叠放依赖。

- Standalone PR, no stacked dependencies.

## 关联 / Related

- 无关联 issue（代码卫生修复）/ No related issue (code hygiene fix).
