### PR TITLE
[Feature] 监控系统隧道状态同步 / Sync tunnel status for monitor system

### DIFF
--- a/backend/api/handlers/monitor.go
+++ b/backend/api/handlers/monitor.go
@@ -10,18 +10,33 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/netpanel/netpanel/model"
+	"github.com/netpanel/netpanel/service/cftunnel"
+	"github.com/netpanel/netpanel/service/easytier"
+	"github.com/netpanel/netpanel/service/frp"
 	"github.com/netpanel/netpanel/service/monitor"
+	"github.com/netpanel/netpanel/service/nps"
+	"github.com/netpanel/netpanel/service/wireguard"
 )
 
 // MonitorHandler 监控模块 Handler
 type MonitorHandler struct {
-	manager *monitor.Manager
+	manager      *monitor.Manager
+	frpMgr       *frp.Manager
+	npsMgr       *nps.Manager
+	easytierMgr  *easytier.Manager
+	cftunnelMgr  *cftunnel.Manager
+	wireguardMgr *wireguard.Manager
 }
 
 // NewMonitorHandler 创建监控 Handler
-func NewMonitorHandler(db *gorm.DB) *MonitorHandler {
+func NewMonitorHandler(db *gorm.DB, frpMgr *frp.Manager, npsMgr *nps.Manager, easytierMgr *easytier.Manager, cftunnelMgr *cftunnel.Manager, wireguardMgr *wireguard.Manager) *MonitorHandler {
 	return &MonitorHandler{
-		manager: monitor.NewManager(db),
+		manager:      monitor.NewManager(db),
+		frpMgr:       frpMgr,
+		npsMgr:       npsMgr,
+		easytierMgr:  easytierMgr,
+		cftunnelMgr:  cftunnelMgr,
+		wireguardMgr: wireguardMgr,
 	}
 }
 
@@ -757,17 +772,44 @@ func (h *MonitorHandler) DeleteTunnelBinding(c *gin.Context) {
 // SyncTunnelStatus 同步隧道状态
 func (h *MonitorHandler) SyncTunnelStatus(c *gin.Context) {
 	id, _ := strconv.ParseUint(c.Param("id"), 10, 32)
-	
+
 	var binding model.MonitorTunnelBinding
 	if err := h.manager.DB.First(&binding, id).Error; err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "绑定不存在"})
 		return
 	}
-	
-	// TODO: 根据 tunnel_type 调用对应的服务获取状态
-	// 这里需要集成 frp/nps/easytier/cftunnel/wireguard 的状态查询
-	binding.TunnelStatus = "connected" // 示例
+
+	// 根据 tunnel_type 调用对应服务的状态查询
+	binding.TunnelStatus = h.queryTunnelStatus(binding.TunnelType, binding.TunnelID)
 	h.manager.DB.Save(&binding)
-	
+
 	c.JSON(http.StatusOK, gin.H{"message": "同步成功", "status": binding.TunnelStatus})
+}
+
+// queryTunnelStatus 查询隧道状态并映射为 connected/disconnected/unknown
+func (h *MonitorHandler) queryTunnelStatus(tunnelType string, tunnelID uint) string {
+	var status string
+	switch tunnelType {
+	case "frp":
+		status = h.frpMgr.GetClientStatus(tunnelID)
+	case "nps":
+		status = h.npsMgr.GetClientStatus(tunnelID)
+	case "easytier":
+		status = h.easytierMgr.GetClientStatus(tunnelID)
+	case "cftunnel":
+		status = h.cftunnelMgr.GetStatus(tunnelID)
+	case "wireguard":
+		status = h.wireguardMgr.GetStatus(tunnelID)
+	default:
+		return "unknown"
+	}
+
+	switch status {
+	case "running":
+		return "connected"
+	case "stopped":
+		return "disconnected"
+	default:
+		return "unknown"
+	}
 }

--- a/backend/api/handlers/monitor_test.go
+++ b/backend/api/handlers/monitor_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+
+	"github.com/netpanel/netpanel/service/cftunnel"
+	"github.com/netpanel/netpanel/service/easytier"
+	"github.com/netpanel/netpanel/service/frp"
+	"github.com/netpanel/netpanel/service/nps"
+	"github.com/netpanel/netpanel/service/wireguard"
+)
+
+// newTestMonitorHandler 构造带内存数据库与各隧道 manager 的测试 Handler
+func newTestMonitorHandler(t *testing.T) *MonitorHandler {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("打开内存数据库失败: %v", err)
+	}
+
+	log := logrus.New()
+	dataDir := t.TempDir()
+
+	return NewMonitorHandler(
+		db,
+		frp.NewManager(db, log),
+		nps.NewManager(db, log, dataDir),
+		easytier.NewManager(db, log, dataDir),
+		cftunnel.NewManager(db, log, dataDir),
+		wireguard.NewManager(db, log, dataDir),
+	)
+}
+
+// TestQueryTunnelStatus_StoppedManager 未启动的隧道 manager 应映射为 disconnected
+func TestQueryTunnelStatus_StoppedManager(t *testing.T) {
+	h := newTestMonitorHandler(t)
+
+	cases := []struct {
+		name       string
+		tunnelType string
+		want       string
+	}{
+		{"frp", "frp", "disconnected"},
+		{"nps", "nps", "disconnected"},
+		{"easytier", "easytier", "disconnected"},
+		{"cftunnel", "cftunnel", "disconnected"},
+		{"wireguard", "wireguard", "disconnected"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := h.queryTunnelStatus(tc.tunnelType, 1)
+			if got != tc.want {
+				t.Fatalf("queryTunnelStatus(%q) = %q, want %q", tc.tunnelType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestQueryTunnelStatus_UnknownType 未知隧道类型应返回 unknown
+func TestQueryTunnelStatus_UnknownType(t *testing.T) {
+	h := newTestMonitorHandler(t)
+
+	if got := h.queryTunnelStatus("unknown-svc", 1); got != "unknown" {
+		t.Fatalf("queryTunnelStatus(unknown-svc) = %q, want %q", got, "unknown")
+	}
+}
+
+// TestSyncTunnelStatus_NotFound 不存在的绑定应返回 404
+func TestSyncTunnelStatus_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newTestMonitorHandler(t)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "99999"}}
+
+	h.SyncTunnelStatus(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("SyncTunnelStatus 不存在绑定返回 %d, want %d", w.Code, http.StatusNotFound)
+	}
+}

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -477,7 +477,7 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	auth.POST("/ai/plugins/:id/toggle", aiHandler.TogglePlugin)
 
 	// ── 服务监控 ────────────────────────────────────────────────────────────────
-	monitorHandler := handlers.NewMonitorHandler(opts.DB)
+	monitorHandler := handlers.NewMonitorHandler(opts.DB, opts.FrpMgr, opts.NpsMgr, opts.EasytierMgr, opts.CftunnelMgr, opts.WireguardMgr)
 	// 服务器管理
 	auth.GET("/monitor/servers", monitorHandler.ListServers)
 	auth.GET("/monitor/servers/:id", monitorHandler.GetServer)


### PR DESCRIPTION
### 中文

实现监控隧道绑定的真实状态同步(替换 `SyncTunnelStatus` 中硬编码 `"connected"` 的 TODO)。

**改动**
- `MonitorHandler` 注入 frp/nps/easytier/cftunnel/wireguard 5 个隧道 manager
- 新增 `queryTunnelStatus`:按 `tunnel_type` 分派状态查询,映射 `running→connected` / `stopped→disconnected` / 未知→`unknown`
- `SyncTunnelStatus` 真实查询并落库,移除 TODO 占位
- router.go 接线传入各 manager
- 新增 `monitor_test.go`:状态映射 5 例 + 未知类型 + 不存在绑定 404

**验证**:`go build ./...` 通过,`go vet` 无新增告警,handlers 测试 7/7 通过,前端 `tsc --noEmit` 通过。

---

### English

Implements real status sync for monitor tunnel bindings (replaces the hardcoded `"connected"` TODO in `SyncTunnelStatus`).

**Changes**
- `MonitorHandler` now receives the frp/nps/easytier/cftunnel/wireguard tunnel managers
- Adds `queryTunnelStatus`: dispatches by `tunnel_type`, mapping `running→connected` / `stopped→disconnected` / unknown→`unknown`
- `SyncTunnelStatus` queries real status and persists it, removing the TODO placeholder
- router.go wires the managers in
- Adds `monitor_test.go`: 5 status-mapping cases + unknown type + 404 for missing binding

**Verification**: `go build ./...` passes, `go vet` has no new warnings, handlers tests 7/7 pass, frontend `tsc --noEmit` passes.