### PR TITLE
[Feature] 监控系统 SMTP 邮件通知 / SMTP email notification for monitor system

### DIFF
--- a/backend/service/monitor/notification.go
+++ b/backend/service/monitor/notification.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"mime"
 	"net/http"
+	"net/smtp"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -75,9 +77,68 @@ func (n *NotificationManager) sendWebhook(account model.CallbackAccount, title, 
 
 // sendEmail 发送邮件通知
 func (n *NotificationManager) sendEmail(account model.CallbackAccount, title, message string) error {
-	// TODO: 实现 SMTP 邮件发送
-	log.Printf("[Notification] 邮件通知暂未实现: %s\n", title)
+	var config map[string]interface{}
+	if err := json.Unmarshal([]byte(account.Config), &config); err != nil {
+		return err
+	}
+
+	host, _ := config["smtp_host"].(string)
+	if host == "" {
+		return fmt.Errorf("SMTP 服务器地址未配置")
+	}
+	port := 587
+	if p, ok := config["smtp_port"].(float64); ok && p > 0 {
+		port = int(p)
+	}
+	user, _ := config["smtp_user"].(string)
+	password, _ := config["smtp_password"].(string)
+	from, _ := config["smtp_from"].(string)
+	if from == "" {
+		return fmt.Errorf("发件人地址未配置")
+	}
+	toEmails := parseEmailList(config["to_emails"])
+	if len(toEmails) == 0 {
+		return fmt.Errorf("收件人地址未配置")
+	}
+
+	msg := buildEmailMessage(from, toEmails, title, message)
+	addr := fmt.Sprintf("%s:%d", host, port)
+
+	var auth smtp.Auth
+	if user != "" {
+		auth = smtp.PlainAuth("", user, password, host)
+	}
+
+	if err := smtp.SendMail(addr, auth, from, toEmails, msg); err != nil {
+		return fmt.Errorf("SMTP 发送失败: %w", err)
+	}
 	return nil
+}
+
+// parseEmailList 解析逗号分隔的收件人列表并去空
+func parseEmailList(raw interface{}) []string {
+	s, _ := raw.(string)
+	if s == "" {
+		return nil
+	}
+	var emails []string
+	for _, part := range strings.Split(s, ",") {
+		if e := strings.TrimSpace(part); e != "" {
+			emails = append(emails, e)
+		}
+	}
+	return emails
+}
+
+// buildEmailMessage 构造 RFC 5322 邮件内容
+func buildEmailMessage(from string, to []string, title, message string) []byte {
+	var buf bytes.Buffer
+	header := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\nDate: %s\r\n\r\n",
+		from, strings.Join(to, ", "), mime.QEncoding.Encode("UTF-8", title), time.Now().Format(time.RFC1123Z))
+	buf.WriteString(header)
+	buf.WriteString(message)
+	buf.WriteString("\r\n")
+	return buf.Bytes()
 }
 
 // sendWechatWork 发送企业微信通知

--- a/backend/service/monitor/notification_test.go
+++ b/backend/service/monitor/notification_test.go
@@ -1,0 +1,90 @@
+package monitor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/netpanel/netpanel/model"
+)
+
+// TestParseEmailList 收件人列表解析与去空
+func TestParseEmailList(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  interface{}
+		want int
+	}{
+		{"正常列表", "a@x.com, b@y.com, c@z.com", 3},
+		{"带空项", "a@x.com,, ,b@y.com", 2},
+		{"空白字符串", "   ", 0},
+		{"空值", "", 0},
+		{"非字符串", 123, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseEmailList(tc.raw)
+			if len(got) != tc.want {
+				t.Fatalf("parseEmailList(%v) 长度 = %d, want %d", tc.raw, len(got), tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildEmailMessage 邮件内容包含必要头字段
+func TestBuildEmailMessage(t *testing.T) {
+	msg := buildEmailMessage("from@x.com", []string{"to@y.com", "to2@z.com"}, "测试标题", "测试正文")
+
+	s := string(msg)
+	for _, want := range []string{
+		"From: from@x.com",
+		"To: to@y.com, to2@z.com",
+		"Subject: =?UTF-8?",
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=UTF-8",
+		"测试正文",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("邮件内容缺少 %q", want)
+		}
+	}
+}
+
+// TestSendEmail_缺配置 sendEmail 缺少关键配置应返回错误
+func TestSendEmail_缺配置(t *testing.T) {
+	n := &NotificationManager{}
+
+	// 空配置
+	if err := n.sendEmail(model.CallbackAccount{Config: "{}"}, "t", "m"); err == nil {
+		t.Fatal("空配置应返回错误")
+	}
+
+	// 缺发件人
+	cfg := `{"smtp_host":"smtp.x.com","smtp_port":587,"smtp_user":"u","smtp_password":"p","to_emails":"a@x.com"}`
+	if err := n.sendEmail(model.CallbackAccount{Config: cfg}, "t", "m"); err == nil {
+		t.Fatal("缺发件人应返回错误")
+	}
+
+	// 缺收件人
+	cfg = `{"smtp_host":"smtp.x.com","smtp_port":587,"smtp_from":"f@x.com"}`
+	if err := n.sendEmail(model.CallbackAccount{Config: cfg}, "t", "m"); err == nil {
+		t.Fatal("缺收件人应返回错误")
+	}
+
+	// 非法 JSON
+	if err := n.sendEmail(model.CallbackAccount{Config: "{bad"}, "t", "m"); err == nil {
+		t.Fatal("非法 JSON 应返回错误")
+	}
+}
+
+// TestSendEmail_配置合法但连接失败 完整配置应尝试连接并返回失败(而非"未实现"式静默成功)
+func TestSendEmail_配置合法但连接失败(t *testing.T) {
+	n := &NotificationManager{}
+	cfg := `{"smtp_host":"127.0.0.1","smtp_port":1,"smtp_user":"u","smtp_password":"p","smtp_from":"f@x.com","to_emails":"a@x.com"}`
+
+	if err := n.sendEmail(model.CallbackAccount{Config: cfg}, "t", "m"); err == nil {
+		t.Fatal("连接失败应返回错误")
+	} else if !strings.Contains(err.Error(), "SMTP 发送失败") {
+		t.Fatalf("错误应包含 SMTP 发送失败, got: %v", err)
+	}
+}


### PR DESCRIPTION
### 中文

实现监控系统的 SMTP 邮件通知(替换 `notification.go` 中 `sendEmail` 的 TODO 占位)。

**改动**
- `sendEmail` 解析 `smtp_host` / `smtp_port` / `smtp_user` / `smtp_password` / `smtp_from` / `to_emails` 配置,用 `net/smtp` 发送 RFC 5322 邮件
- 中文标题使用 MIME Q 编码,收件人逗号分隔并去空
- 配置缺失/非法返回明确错误;连接失败包装为「SMTP 发送失败」
- 新增 `notification_test.go`:收件人解析 5 例 + 邮件构造 + 缺配置 + 连接失败

**验证**:`go build ./...` 通过,`go vet` 无新增告警,monitor 包测试 8/8 通过,前端 `tsc --noEmit` 通过。

---

### English

Implements SMTP email notification for the monitor system (replaces the TODO placeholder in `sendEmail` in `notification.go`).

**Changes**
- `sendEmail` parses `smtp_host` / `smtp_port` / `smtp_user` / `smtp_password` / `smtp_from` / `to_emails` config and sends an RFC 5322 email via `net/smtp`
- Chinese subject encoded with MIME Q-encoding; recipients split by comma with empty entries removed
- Missing/invalid config returns clear errors; connection failures are wrapped as "SMTP 发送失败"
- Adds `notification_test.go`: 5 recipient-parsing cases + message building + missing config + connection failure

**Verification**: `go build ./...` passes, `go vet` has no new warnings, monitor tests 8/8 pass, frontend `tsc --noEmit` passes.