### PR TITLE
[Feature] 防火墙 IPv6 规则支持 / IPv6 rule support for firewall (#24 P1)

### DIFF
--- a/backend/model/models.go
+++ b/backend/model/models.go
@@ -1014,6 +1014,8 @@ type FirewallRule struct {
 	BaseModel
 	Name   string `gorm:"size:100;not null" json:"name"`
 	Enable bool   `gorm:"default:false" json:"enable"`
+	// IP 版本：4（IPv4）/ 6（IPv6），默认 4
+	IPVersion int `gorm:"default:4" json:"ip_version"`
 	// 方向：in（入站）/ out（出站）
 	Direction string `gorm:"size:10;default:'in'" json:"direction"`
 	// 动作：allow（允许）/ deny（拒绝/丢弃）

--- a/backend/service/firewall/manager.go
+++ b/backend/service/firewall/manager.go
@@ -264,12 +264,20 @@ func (m *Manager) RemoveRule(rule *model.FirewallRule) error {
 
 func (m *Manager) applyIptables(rule *model.FirewallRule) error {
 	args := m.buildIptablesArgs(rule, "-A")
-	return runCmd("iptables", args...)
+	return runCmd(m.iptablesCmd(rule), args...)
 }
 
 func (m *Manager) removeIptables(rule *model.FirewallRule) error {
 	args := m.buildIptablesArgs(rule, "-D")
-	return runCmd("iptables", args...)
+	return runCmd(m.iptablesCmd(rule), args...)
+}
+
+// iptablesCmd 根据 IP 版本选择 iptables / ip6tables 命令
+func (m *Manager) iptablesCmd(rule *model.FirewallRule) string {
+	if rule.IPVersion == 6 {
+		return "ip6tables"
+	}
+	return "iptables"
 }
 
 func (m *Manager) buildIptablesArgs(rule *model.FirewallRule, op string) []string {
@@ -291,6 +299,10 @@ func (m *Manager) buildIptablesArgs(rule *model.FirewallRule, op string) []strin
 		if proto == "tcp+udp" {
 			// iptables 不支持 tcp+udp，需要分两条，这里先用 tcp
 			proto = "tcp"
+		}
+		// IPv6 下 ICMP 为 icmpv6，规则可适配
+		if rule.IPVersion == 6 && proto == "icmp" {
+			proto = "icmpv6"
 		}
 		args = append(args, "-p", proto)
 	}

--- a/backend/service/firewall/manager_test.go
+++ b/backend/service/firewall/manager_test.go
@@ -1,0 +1,106 @@
+package firewall
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/netpanel/netpanel/model"
+)
+
+// TestIptablesCmd IP 版本对应命令选择
+func TestIptablesCmd(t *testing.T) {
+	m := &Manager{}
+
+	cases := []struct {
+		name string
+		rule *model.FirewallRule
+		want string
+	}{
+		{"默认 IPv4", &model.FirewallRule{}, "iptables"},
+		{"显式 IPv4", &model.FirewallRule{IPVersion: 4}, "iptables"},
+		{"IPv6", &model.FirewallRule{IPVersion: 6}, "ip6tables"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := m.iptablesCmd(tc.rule); got != tc.want {
+				t.Fatalf("iptablesCmd() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildIptablesArgs_IPv4 IPv4 规则参数构造
+func TestBuildIptablesArgs_IPv4(t *testing.T) {
+	m := &Manager{}
+	rule := &model.FirewallRule{
+		IPVersion: 4,
+		Direction: "in",
+		Action:    "allow",
+		Protocol:  "tcp",
+		SrcIP:     "192.168.1.0/24",
+		DstIP:     "10.0.0.1",
+		Port:      "8080",
+	}
+
+	got := m.buildIptablesArgs(rule, "-A")
+	want := []string{"-A", "INPUT", "-p", "tcp", "-s", "192.168.1.0/24", "-d", "10.0.0.1", "--dport", "8080", "-j", "ACCEPT"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildIptablesArgs(IPv4) = %v, want %v", got, want)
+	}
+}
+
+// TestBuildIptablesArgs_IPv6 IPv6 规则参数构造(含 icmp→icmpv6 适配)
+func TestBuildIptablesArgs_IPv6(t *testing.T) {
+	m := &Manager{}
+	rule := &model.FirewallRule{
+		IPVersion: 6,
+		Direction: "in",
+		Action:    "allow",
+		Protocol:  "icmp",
+		SrcIP:     "2001:db8::/32",
+		DstIP:     "2001:db8::1",
+	}
+
+	got := m.buildIptablesArgs(rule, "-A")
+	want := []string{"-A", "INPUT", "-p", "icmpv6", "-s", "2001:db8::/32", "-d", "2001:db8::1", "-j", "ACCEPT"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildIptablesArgs(IPv6) = %v, want %v", got, want)
+	}
+}
+
+// TestBuildIptablesArgs_IPv6TCP IPv6 TCP 端口规则
+func TestBuildIptablesArgs_IPv6TCP(t *testing.T) {
+	m := &Manager{}
+	rule := &model.FirewallRule{
+		IPVersion: 6,
+		Direction: "in",
+		Action:    "deny",
+		Protocol:  "tcp",
+		Port:      "443",
+	}
+
+	got := m.buildIptablesArgs(rule, "-D")
+	want := []string{"-D", "INPUT", "-p", "tcp", "--dport", "443", "-j", "DROP"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildIptablesArgs(IPv6 TCP) = %v, want %v", got, want)
+	}
+}
+
+// TestBuildIptablesArgs_IPv6端口范围 IPv6 端口范围参数
+func TestBuildIptablesArgs_IPv6端口范围(t *testing.T) {
+	m := &Manager{}
+	rule := &model.FirewallRule{
+		IPVersion: 6,
+		Direction: "in",
+		Action:    "allow",
+		Protocol:  "tcp+udp",
+		Port:      "1000-2000",
+	}
+
+	got := m.buildIptablesArgs(rule, "-A")
+	want := []string{"-A", "INPUT", "-p", "tcp", "--dport", "1000:2000", "-j", "ACCEPT"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildIptablesArgs(IPv6 端口范围) = %v, want %v", got, want)
+	}
+}

--- a/webpage/src/pages/Firewall.tsx
+++ b/webpage/src/pages/Firewall.tsx
@@ -495,6 +495,12 @@ const Firewall: React.FC = () => {
           </Form.Item>
 
           <Space style={{ width: '100%' }} size={12}>
+            <Form.Item name="ip_version" label="IP 版本" initialValue={4} style={{ flex: 1 }}>
+              <Select>
+                <Option value={4}>IPv4</Option>
+                <Option value={6}>IPv6</Option>
+              </Select>
+            </Form.Item>
             <Form.Item name="direction" label="方向" rules={[{ required: true }]} style={{ flex: 1 }}>
               <Select>
                 <Option value="in">入站（Inbound）</Option>


### PR DESCRIPTION
### 中文

统一入口安全网关(issue #24)的 **P1:防火墙 IPv6 支持** —— 打通 IPv6 直连的放行缺口(很多用户只有公网 IPv6,IPv4 为 CGNAT)。

**改动**
- `FirewallRule` 模型新增 `IPVersion` 字段(4/6,默认 4)
- `applyIptables` / `removeIptables` 按版本选择 `iptables` / `ip6tables` 命令
- `buildIptablesArgs` 适配 IPv6:ICMP 规则在 IPv6 下映射为 `icmpv6`
- 前端防火墙规则表单新增 IP 版本选择(IPv4/IPv6)
- 新增 `manager_test.go` 5 例:命令选择 + IPv4/IPv6/端口范围参数构造

**验证**:`go build ./...` 通过,`go vet` 无新增告警,firewall 测试 5/5 通过,前端 `tsc --noEmit` 通过。

**后续**:P2 WAF 引擎接线 → P3 IPv6 直连完整链路 → P4 NAT64/DNS64,见 issue #24。

---

### English

**P1: Firewall IPv6 support** of the unified secure ingress (issue #24) — unblocks the IPv6 direct-access firewall gap (many users have public IPv6 only, IPv4 behind CGNAT).

**Changes**
- `FirewallRule` model gains an `IPVersion` field (4/6, default 4)
- `applyIptables` / `removeIptables` pick `iptables` / `ip6tables` by version
- `buildIptablesArgs` adapts for IPv6: ICMP rules map to `icmpv6` on IPv6
- Firewall rule form gains an IP-version selector (IPv4/IPv6)
- Adds `manager_test.go` with 5 cases: command selection + IPv4/IPv6/port-range argument construction

**Verification**: `go build ./...` passes, `go vet` has no new warnings, firewall tests 5/5 pass, frontend `tsc --noEmit` passes.

**Next**: P2 WAF engine wiring → P3 full IPv6 direct-access chain → P4 NAT64/DNS64, tracked in issue #24.