### PR TITLE
[Feature] IPv6 直达地址展示 / IPv6 direct-access display (#24 P3)

### DIFF
--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -931,6 +931,8 @@ const en = {
     // Table columns
     listenAddress: 'Listen Address',
     targetOrPath: 'Target/Path',
+    ipv6Direct: 'IPv6 Direct',
+    ipv6DirectTip: 'Caddy listens dual-stack: once a DDNS IPv6 (AAAA) task is configured and the firewall opens the IPv6 port, external IPv6 clients can reach the site directly via https://domain:port',
     // Form
     namePlaceholder: 'Site name',
     listenSettings: 'Listen Settings',

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -943,6 +943,8 @@ const zh = {
     // 表格列
     listenAddress: '监听地址',
     targetOrPath: '目标/路径',
+    ipv6Direct: 'IPv6 直达',
+    ipv6DirectTip: 'Caddy 双栈监听中:配置 DDNS IPv6(AAAA)任务并在防火墙放行 IPv6 端口后,外部 IPv6 客户端可通过 https://域名:端口 直达',
     // 表单
     namePlaceholder: '站点名称',
     listenSettings: '监听设置',

--- a/webpage/src/pages/Caddy.tsx
+++ b/webpage/src/pages/Caddy.tsx
@@ -107,6 +107,11 @@ const Caddy: React.FC = () => {
             : <Tag icon={<LinkOutlined />}>http</Tag>
           }
           <Text code>{r.domain || '*'}:{r.port || 80}</Text>
+          {r.domain && r.domain !== '*' && !r.domain.startsWith(':') && (
+            <Tooltip title={t('caddy.ipv6DirectTip')}>
+              <Tag icon={<LinkOutlined />} color="purple">{t('caddy.ipv6Direct')}</Tag>
+            </Tooltip>
+          )}
         </Space>
       ),
     },


### PR DESCRIPTION
### 中文

统一入口安全网关(issue #24)的 **P3:IPv6 直连完整链路的前端展示**。

**背景**:Caddy `:port` 监听天然双栈(IPv4+IPv6);DDNS 已支持 IPv6(AAAA)任务;防火墙 IPv6 放行由 P1(PR #25)补齐。本 PR 补齐链路末端的**前端展示与引导**。

**改动**
- Caddy 站点「监听地址」列新增 **IPv6 直达**标签(Tooltip 说明):配置 DDNS IPv6(AAAA)任务 + 防火墙放行 IPv6 端口后,外部 IPv6 客户端可通过 `https://域名:端口` 直达
- i18n 新增 `caddy.ipv6Direct` / `caddy.ipv6DirectTip`(zh/en)

**验证**:前端 `tsc --noEmit` 通过,`go build ./...` / `go vet` 通过(无后端改动)。

**后续**:P4 NAT64/DNS64 → P5 使用引导,见 issue #24。

---

### English

**P3: Frontend display for the IPv6 direct-access chain** of the unified secure ingress (issue #24).

**Background**: Caddy `:port` listens dual-stack (IPv4+IPv6) natively; DDNS already supports IPv6 (AAAA) tasks; firewall IPv6 opening was completed in P1 (PR #25). This PR completes the frontend display and guidance at the end of the chain.

**Changes**
- The Caddy site "Listen Address" column gains an **IPv6 Direct** tag (with tooltip): after configuring a DDNS IPv6 (AAAA) task and opening the IPv6 port in the firewall, external IPv6 clients can reach the site directly via `https://domain:port`
- i18n adds `caddy.ipv6Direct` / `caddy.ipv6DirectTip` (zh/en)

**Verification**: frontend `tsc --noEmit` passes; `go build ./...` / `go vet` pass (no backend changes).

**Next**: P4 NAT64/DNS64 → P5 usage guidance, tracked in issue #24.