### PR TITLE
[Feature] DNS64 支持 — 为纯 IPv6 客户端合成 NAT64 AAAA / DNS64: synthesize NAT64 AAAA for pure-IPv6 clients (#24 P4)

### DIFF
--- a/backend/model/models.go
+++ b/backend/model/models.go
@@ -873,6 +873,9 @@ type DnsmasqConfig struct {
 	ListenAddr  string `gorm:"size:100;default:'0.0.0.0'" json:"listen_addr"`
 	ListenPort  int    `gorm:"default:53" json:"listen_port"`
 	UpstreamDNS string `gorm:"type:text" json:"upstream_dns"` // JSON 数组
+	// DNS64:纯 IPv6 客户端访问 IPv4 服务时,为无 AAAA 记录的域名合成 NAT64 前缀的 AAAA
+	EnableDNS64 bool   `gorm:"default:false" json:"enable_dns64"`
+	NAT64Prefix string `gorm:"size:64;default:'64:ff9b::/96'" json:"nat64_prefix"`
 	Status      string `gorm:"size:20;default:'stopped'" json:"status"`
 	LastError   string `gorm:"type:text" json:"last_error"`
 }

--- a/backend/service/dnsmasq/dns64_test.go
+++ b/backend/service/dnsmasq/dns64_test.go
@@ -1,0 +1,89 @@
+package dnsmasq
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestHasAAAA 应答中是否已有 AAAA 记录
+func TestHasAAAA(t *testing.T) {
+	none := []dns.RR{}
+	if hasAAAA(none) {
+		t.Fatal("空应答不应包含 AAAA")
+	}
+
+	aOnly := []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "x.", Rrtype: dns.TypeA}, A: net.ParseIP("1.2.3.4").To4()}}
+	if hasAAAA(aOnly) {
+		t.Fatal("仅 A 记录不应判定为有 AAAA")
+	}
+
+	withAAAA := []dns.RR{&dns.AAAA{Hdr: dns.RR_Header{Name: "x.", Rrtype: dns.TypeAAAA}, AAAA: net.ParseIP("2001:db8::1")}}
+	if !hasAAAA(withAAAA) {
+		t.Fatal("含 AAAA 记录应判定为有 AAAA")
+	}
+}
+
+// TestSynthesizeAAAA_默认前缀 默认 64:ff9b::/96 前缀合成
+func TestSynthesizeAAAA_默认前缀(t *testing.T) {
+	aAnswers := []dns.RR{
+		&dns.A{Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA}, A: net.ParseIP("1.2.3.4").To4()},
+	}
+
+	out := synthesizeAAAA(aAnswers, "64:ff9b::/96")
+	if len(out) != 1 {
+		t.Fatalf("应合成 1 条 AAAA, got %d", len(out))
+	}
+	aaaa, ok := out[0].(*dns.AAAA)
+	if !ok {
+		t.Fatalf("合成记录应为 AAAA, got %T", out[0])
+	}
+	want := net.ParseIP("64:ff9b::102:304") // 64:ff9b::0102:0304
+	if !aaaa.AAAA.Equal(want) {
+		t.Fatalf("合成 AAAA = %s, want %s", aaaa.AAAA, want)
+	}
+}
+
+// TestSynthesizeAAAA_非法前缀 非法前缀返回 nil
+func TestSynthesizeAAAA_非法前缀(t *testing.T) {
+	aAnswers := []dns.RR{
+		&dns.A{Hdr: dns.RR_Header{Name: "x.", Rrtype: dns.TypeA}, A: net.ParseIP("1.2.3.4").To4()},
+	}
+	if out := synthesizeAAAA(aAnswers, "not-a-prefix"); out != nil {
+		t.Fatalf("非法前缀应返回 nil, got %v", out)
+	}
+}
+
+// TestSynthesizeAAAA_自定义前缀 自定义 96 位前缀
+func TestSynthesizeAAAA_自定义前缀(t *testing.T) {
+	aAnswers := []dns.RR{
+		&dns.A{Hdr: dns.RR_Header{Name: "x.", Rrtype: dns.TypeA}, A: net.ParseIP("10.0.0.1").To4()},
+	}
+	out := synthesizeAAAA(aAnswers, "2001:db8:64::/96")
+	if len(out) != 1 {
+		t.Fatalf("应合成 1 条 AAAA, got %d", len(out))
+	}
+	aaaa, _ := out[0].(*dns.AAAA)
+	want := net.ParseIP("2001:db8:64::a00:1") // 2001:db8:64::0a00:0001
+	if !aaaa.AAAA.Equal(want) {
+		t.Fatalf("合成 AAAA = %s, want %s", aaaa.AAAA, want)
+	}
+}
+
+// TestAQueryFromAAAA AAAA 查询转 A 查询
+func TestAQueryFromAAAA(t *testing.T) {
+	q := &dns.Msg{}
+	q.SetQuestion("example.com.", dns.TypeAAAA)
+	a := aQueryFromAAAA(q)
+
+	if len(a.Question) != 1 {
+		t.Fatalf("A 查询应有 1 个问题, got %d", len(a.Question))
+	}
+	if a.Question[0].Qtype != dns.TypeA {
+		t.Fatalf("A 查询 Qtype = %d, want %d", a.Question[0].Qtype, dns.TypeA)
+	}
+	if a.Question[0].Name != "example.com." {
+		t.Fatalf("A 查询域名 = %s, want example.com.", a.Question[0].Name)
+	}
+}

--- a/backend/service/dnsmasq/manager.go
+++ b/backend/service/dnsmasq/manager.go
@@ -173,6 +173,13 @@ func (m *Manager) forwardToUpstream(w dns.ResponseWriter, r *dns.Msg) {
 		}
 		resp, _, err := c.Exchange(r, upstream)
 		if err == nil {
+			// DNS64:纯 IPv6 客户端请求 AAAA 但上游无 AAAA 记录时,
+			// 用 A 记录 + NAT64 前缀合成 AAAA,让 IPv6 客户端可访问 IPv4 服务
+			if cfg.EnableDNS64 && len(r.Question) > 0 && r.Question[0].Qtype == dns.TypeAAAA && !hasAAAA(resp.Answer) {
+				if aResp, _, aErr := c.Exchange(aQueryFromAAAA(r), upstream); aErr == nil {
+					resp.Answer = append(resp.Answer, synthesizeAAAA(aResp.Answer, cfg.NAT64Prefix)...)
+				}
+			}
 			resp.SetReply(r)
 			w.WriteMsg(resp)
 			return
@@ -183,4 +190,53 @@ func (m *Manager) forwardToUpstream(w dns.ResponseWriter, r *dns.Msg) {
 	msg := new(dns.Msg)
 	msg.SetRcode(r, dns.RcodeServerFailure)
 	w.WriteMsg(msg)
+}
+
+// aQueryFromAAAA 由 AAAA 查询构造同域名的 A 查询
+func aQueryFromAAAA(r *dns.Msg) *dns.Msg {
+	q := &dns.Msg{}
+	q.SetQuestion(r.Question[0].Name, dns.TypeA)
+	return q
+}
+
+// hasAAAA 判断应答中是否已有 AAAA 记录
+func hasAAAA(answers []dns.RR) bool {
+	for _, rr := range answers {
+		if _, ok := rr.(*dns.AAAA); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// synthesizeAAAA 用 A 记录与 NAT64 前缀合成 AAAA 记录
+// 前缀默认 64:ff9b::/96,合成规则:前缀前 96 位 + IPv4 后 32 位
+func synthesizeAAAA(aAnswers []dns.RR, prefix string) []dns.RR {
+	// 解析前缀
+	_, prefixNet, err := net.ParseCIDR(prefix)
+	if err != nil {
+		return nil
+	}
+	prefixBytes := prefixNet.IP.To16()
+	if prefixBytes == nil {
+		return nil
+	}
+
+	var out []dns.RR
+	for _, rr := range aAnswers {
+		a, ok := rr.(*dns.A)
+		if !ok || a.A == nil {
+			continue
+		}
+		ipv6 := make(net.IP, 16)
+		// 前缀前 12 字节(96 位)
+		copy(ipv6[:12], prefixBytes[:12])
+		// IPv4 后 4 字节(32 位)
+		copy(ipv6[12:], a.A.To4())
+		out = append(out, &dns.AAAA{
+			Hdr:  dns.RR_Header{Name: a.Hdr.Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+			AAAA: ipv6,
+		})
+	}
+	return out
 }

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -1254,6 +1254,9 @@ const en = {
     listenPort: 'Listen Port',
     upstreamDNS: 'Upstream DNS',
     customRecords: 'Custom Records',
+    enableDns64: 'Enable DNS64 (IPv6→IPv4 translation)',
+    nat64Prefix: 'NAT64 Prefix',
+    dns64Tip: 'For pure-IPv6 clients querying domains without AAAA records, synthesize AAAA from A records + NAT64 prefix so they can reach IPv4 services via a NAT64 gateway',
   },
   cron: {
     title: 'Cron Job',

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -1281,6 +1281,9 @@ const zh = {
     listenPort: '监听端口',
     upstreamDNS: '上游DNS',
     customRecords: '自定义解析',
+    enableDns64: '启用 DNS64(IPv6→IPv4 转换)',
+    nat64Prefix: 'NAT64 前缀',
+    dns64Tip: '纯 IPv6 客户端查询无 AAAA 记录的域名时,用 A 记录 + NAT64 前缀合成 AAAA,配合 NAT64 网关即可访问 IPv4 服务',
   },
   // 计划任务
   cron: {

--- a/webpage/src/pages/Dnsmasq.tsx
+++ b/webpage/src/pages/Dnsmasq.tsx
@@ -76,6 +76,18 @@ const Dnsmasq: React.FC = () => {
             <Col span={8}><Form.Item name="listen_port" label={t('dnsmasq.listenPort')}><InputNumber min={1} max={65535} style={{ width: '100%' }} /></Form.Item></Col>
             <Col span={8}><Form.Item name="upstream_dns" label={t('dnsmasq.upstreamDNS')}><Input placeholder="8.8.8.8,114.114.114.114" style={{ width: '100%' }} /></Form.Item></Col>
           </Row>
+          <Row gutter={16}>
+            <Col span={8}>
+              <Form.Item name="enable_dns64" label={t('dnsmasq.enableDns64')} valuePropName="checked" tooltip={t('dnsmasq.dns64Tip')}>
+                <Switch />
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item name="nat64_prefix" label={t('dnsmasq.nat64Prefix')}>
+                <Input placeholder="64:ff9b::/96" style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+          </Row>
           <Button type="primary" onClick={handleSaveConfig}>{t('common.save')}</Button>
         </Form>
       </Card>


### PR DESCRIPTION
### 中文

统一入口安全网关(issue #24)的 **P4:DNS64 支持** —— 让纯 IPv6 客户端能访问 IPv4 服务。

**背景**:外部用户/设备只有 IPv6、服务只有 IPv4 时,需要 DNS64(合成 NAT64 前缀的 AAAA)+ NAT64 网关(Tayga 等)配合。本 PR 提供 DNS64 合成侧(dnsmasq 为 Go 内置 DNS,纯代码实现,可测试)。

**改动**
- `DnsmasqConfig` 新增 `EnableDNS64` / `NAT64Prefix` 字段(默认 `64:ff9b::/96`)
- `forwardToUpstream`:AAAA 查询且上游无 AAAA 记录时,回查 A 记录并用 NAT64 前缀合成 AAAA(前缀前 96 位 + IPv4 后 32 位),配合 NAT64 网关即可访问 IPv4 服务
- 前端 Dnsmasq 配置新增 DNS64 开关与 NAT64 前缀输入;i18n zh/en
- 新增 `dns64_test.go` 5 例(合成/默认前缀/自定义前缀/非法前缀/查询转换)

**验证**:`go build ./...` 通过,`go vet` 无新增告警,DNS64 单测 5/5 通过,前端 `tsc --noEmit` 通过。

**说明**:Tayga NAT64 网关需 tun 设备与 root 权限,本 PR 提供 DNS64 侧;网关 sidecar 可后续按需补充。

**后续**:P5 使用引导,见 issue #24。

---

### English

**P4: DNS64 support** of the unified secure ingress (issue #24) — lets pure-IPv6 clients reach IPv4 services.

**Background**: when visitors/clients have IPv6 only and the service is IPv4 only, DNS64 (synthesizing AAAA with a NAT64 prefix) plus a NAT64 gateway (e.g. Tayga) is required. This PR provides the DNS64 side (dnsmasq is a Go-embedded DNS server, so this is pure code and testable).

**Changes**
- `DnsmasqConfig` gains `EnableDNS64` / `NAT64Prefix` fields (default `64:ff9b::/96`)
- `forwardToUpstream`: when a AAAA query returns no AAAA from upstream, it re-queries the A record and synthesizes an AAAA from the NAT64 prefix (first 96 bits of prefix + last 32 bits of IPv4), so IPv4 services become reachable through a NAT64 gateway
- Dnsmasq config UI gains a DNS64 toggle and NAT64-prefix input; i18n zh/en
- Adds `dns64_test.go` with 5 cases (synthesis / default prefix / custom prefix / invalid prefix / query conversion)

**Verification**: `go build ./...` passes, `go vet` has no new warnings, DNS64 tests 5/5 pass, frontend `tsc --noEmit` passes.

**Note**: the Tayga NAT64 gateway needs a tun device and root; this PR covers the DNS64 side, a gateway sidecar can be added later.

**Next**: P5 usage guidance, tracked in issue #24.