### PR TITLE
[Feature] 测速弹窗：服务线路即时并发测速 / Speed-test popup: instant concurrent line probing

### DIFF
--- a/backend/api/handlers/tunservice.go
+++ b/backend/api/handlers/tunservice.go
@@ -125,3 +125,24 @@ func (h *TunserviceHandler) History(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"code": 200, "data": history})
 }
+
+// Speedtest 对服务关联线路做一次即时并发测速（延迟升序、失败排最后）。
+// 受 SystemConfig 键 speedtest_popup_enabled 控制（默认开启；设为 false 时 403）。
+func (h *TunserviceHandler) Speedtest(c *gin.Context) {
+	var cfg model.SystemConfig
+	enabled := "true"
+	if err := h.db.Where("key = ?", "speedtest_popup_enabled").First(&cfg).Error; err == nil {
+		enabled = cfg.Value
+	}
+	if enabled == "false" || enabled == "0" {
+		c.JSON(http.StatusForbidden, gin.H{"code": 403, "message": "测速功能已禁用"})
+		return
+	}
+	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
+	lines, err := h.mgr.Speedtest(uint(id))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"code": 404, "message": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"code": 200, "data": lines})
+}

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -204,6 +204,7 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	auth.POST("/tunservice/:id/stop", tsHandler.Stop)
 	auth.GET("/tunservice/:id/candidates", tsHandler.Candidates)
 	auth.GET("/tunservice/:id/history", tsHandler.History)
+	auth.GET("/tunservice/:id/speedtest", tsHandler.Speedtest)
 
 	// 线路探测策略（参数化配置）
 	lineHandler := handlers.NewLineregHandler(opts.DB, opts.Log, opts.LineregMgr)

--- a/backend/model/db.go
+++ b/backend/model/db.go
@@ -158,4 +158,8 @@ func initDefaultData(db *gorm.DB) {
 			Remark:   "系统管理员",
 		})
 	}
+
+	// 测速弹窗开关：确保键存在（默认开启；设为 false 时 Speedtest API 返回 403）
+	db.Where(&SystemConfig{Key: "speedtest_popup_enabled"}).
+		FirstOrCreate(&SystemConfig{Key: "speedtest_popup_enabled", Value: "true"})
 }

--- a/backend/service/linereg/linereg.go
+++ b/backend/service/linereg/linereg.go
@@ -167,6 +167,11 @@ func (m *Manager) Selector() *selector.Selector {
 	return m.selector
 }
 
+// SetProber 透传设置探测器（测试注入 / 即时测速复用）。
+func (m *Manager) SetProber(p selector.Prober) {
+	m.selector.SetProber(p)
+}
+
 // SetInterval 设置线路刷新间隔（须在 Start 前调用）。
 func (m *Manager) SetInterval(d time.Duration) {
 	if d > 0 {

--- a/backend/service/selector/selector.go
+++ b/backend/service/selector/selector.go
@@ -305,6 +305,59 @@ func (s *Selector) Lines() []Line {
 	return append([]Line(nil), s.lines...)
 }
 
+// SetProber 替换探测器（测试注入用）。p 为 nil 时忽略。
+// 须在首次探测前调用，否则不保证生效。
+func (s *Selector) SetProber(p Prober) {
+	if p == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.prober = p
+}
+
+// ProbeLines 对给定线路做一次即时并发测速，不刷新内部选线状态
+// （current/锁线/探测历史均不受影响）。用于「用户手动测速」等一次性场景。
+// 复用与 ProbeAll 相同的信号量限流；返回 lineID -> ProbeResult。
+func (s *Selector) ProbeLines(ctx context.Context, lines []Line) map[string]ProbeResult {
+	if len(lines) == 0 {
+		return map[string]ProbeResult{}
+	}
+	maxConcurrent := s.maxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = 8
+	}
+	s.mu.Lock()
+	prober := s.prober
+	s.mu.Unlock()
+
+	sem := make(chan struct{}, maxConcurrent)
+	results := make(map[string]ProbeResult, len(lines))
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for _, line := range lines {
+		wg.Add(1)
+		go func(l Line) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				mu.Lock()
+				results[l.ID] = ProbeResult{LineID: l.ID, Err: &ProbeError{Reason: "probe canceled"}}
+				mu.Unlock()
+				return
+			}
+			r := prober.Probe(ctx, l)
+			mu.Lock()
+			results[l.ID] = r
+			mu.Unlock()
+		}(line)
+	}
+	wg.Wait()
+	return results
+}
+
 // ProbeAll 并发探测全部线路并刷新结果，返回按线路 id 索引的结果。
 // 并发数受 maxConcurrent 信号量限制，线路过多时不会同时打爆对端/本机连接。
 func (s *Selector) ProbeAll(ctx context.Context) map[string]ProbeResult {

--- a/backend/service/selector/selector_test.go
+++ b/backend/service/selector/selector_test.go
@@ -446,3 +446,52 @@ func TestSetToleranceChangesHysteresisWindow(t *testing.T) {
 		t.Fatalf("with tiny tolerance, expected switch to b, got %q", third.LineID)
 	}
 }
+
+// TestProbeLinesDoesNotMutateState 验证即时测速 ProbeLines 不刷新内部选线状态：
+// 传入线路的子集测速后，内部 results/current 保持原样（不触发切换）。
+func TestProbeLinesDoesNotMutateState(t *testing.T) {
+	s, f := newFake(
+		mkLines("a", "b"),
+		map[string]time.Duration{"a": 10 * time.Millisecond, "b": 200 * time.Millisecond},
+		nil,
+	)
+	s.ProbeAll(context.Background())
+	if sel := s.Select(); sel.LineID != "a" {
+		t.Fatalf("expected current a, got %q", sel.LineID)
+	}
+
+	// 只对 b 做一次即时测速（模拟手动测速），并让 b 变得最快
+	f.latencies["b"] = 5 * time.Millisecond
+	lines := []Line{byID(t, s, "b")}
+	res := s.ProbeLines(context.Background(), lines)
+	if r, ok := res["b"]; !ok || r.Err != nil {
+		t.Fatalf("ProbeLines should return result for b, got %v", res)
+	}
+	// 内部状态未被刷新：current 仍是 a（ProbeLines 不应改变选线结果）
+	if sel := s.Select(); sel.LineID != "a" {
+		t.Fatalf("ProbeLines must not refresh selection state, current should stay a, got %q", sel.LineID)
+	}
+}
+
+// TestProbeLinesCancellation 验证 ctx 取消时 ProbeLines 返回取消结果。
+func TestProbeLinesCancellation(t *testing.T) {
+	s, _ := newFake(mkLines("a"), map[string]time.Duration{"a": 10 * time.Millisecond}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 立即取消
+	res := s.ProbeLines(ctx, mkLines("a"))
+	if r, ok := res["a"]; !ok || r.Err == nil {
+		t.Fatalf("expected canceled result for a, got %v", res)
+	}
+}
+
+// byID 从 Selector 中按 id 取 Line（测试辅助）。
+func byID(t *testing.T, s *Selector, id string) Line {
+	t.Helper()
+	for _, l := range s.Lines() {
+		if l.ID == id {
+			return l
+		}
+	}
+	t.Fatalf("line %q not found", id)
+	return Line{}
+}

--- a/backend/service/tunservice/manager.go
+++ b/backend/service/tunservice/manager.go
@@ -5,8 +5,10 @@
 package tunservice
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -266,6 +268,75 @@ func latencyOf(r selector.ProbeResult) int64 {
 		return int64(r.HTTPLatency)
 	}
 	return int64(r.TCPLatency)
+}
+
+// SpeedtestLine 一次即时测速的单条线路结果。
+type SpeedtestLine struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Tool    string `json:"tool"`
+	Address string `json:"address"`
+	Layer   string `json:"layer"`
+	// Latency 有效延迟（ns）；探测失败为 0。
+	Latency int64  `json:"latency"`
+	// Error 非空表示本次探测失败（超时/拒绝等）。
+	Error string `json:"error,omitempty"`
+}
+
+// Speedtest 对服务的关联线路做一次即时并发测速（不刷新内部选线状态）。
+// 返回按有效延迟升序排列的结果，失败线路排最后。供「测速弹窗」等
+// 用户主动触发的一次性测速使用。
+func (m *Manager) Speedtest(svcID uint) ([]SpeedtestLine, error) {
+	var svc model.TunService
+	if err := m.db.First(&svc, svcID).Error; err != nil {
+		return nil, err
+	}
+	var refs []string
+	if err := json.Unmarshal([]byte(svc.LineRefs), &refs); err != nil {
+		refs = nil
+	}
+	// 从 selector 收集线路静态信息（地址/工具/名称/层次）
+	st := m.linereg.Selector().Snapshot()
+	byID := make(map[string]selector.Line, len(st.Lines))
+	for _, l := range st.Lines {
+		byID[l.ID] = l
+	}
+	var lines []selector.Line
+	for _, ref := range refs {
+		if l, ok := byID[ref]; ok {
+			lines = append(lines, l)
+		}
+	}
+	// 即时并发测速：不刷新内部状态（ProbeLines 语义）
+	results := m.linereg.Selector().ProbeLines(context.Background(), lines)
+
+	out := make([]SpeedtestLine, 0, len(refs))
+	for _, ref := range refs {
+		item := SpeedtestLine{ID: ref}
+		if l, ok := byID[ref]; ok {
+			item.Name = l.Name
+			item.Tool = l.Tool
+			item.Address = l.Address
+			item.Layer = layerFor(l)
+		}
+		if r, ok := results[ref]; ok && r.Err == nil {
+			item.Latency = latencyOf(r)
+		} else if ok && r.Err != nil {
+			item.Error = r.Err.Error()
+		} else {
+			item.Error = "未探测"
+		}
+		out = append(out, item)
+	}
+	// 延迟升序，失败（Error 非空）排最后
+	sort.SliceStable(out, func(i, j int) bool {
+		ei, ej := out[i].Error != "", out[j].Error != ""
+		if ei != ej {
+			return !ei
+		}
+		return out[i].Latency < out[j].Latency
+	})
+	return out, nil
 }
 
 // parseLineID 解析线路 ID："frp:3" -> ("frp", 3)；"easytier:1:0" -> ("easytier", 1)。

--- a/backend/service/tunservice/manager_test.go
+++ b/backend/service/tunservice/manager_test.go
@@ -1,0 +1,138 @@
+package tunservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/netpanel/netpanel/model"
+	"github.com/netpanel/netpanel/service/linereg"
+	"github.com/netpanel/netpanel/service/selector"
+)
+
+// fakeProber 注入式探测器：按线路 id 返回固定延迟/错误。
+type fakeProber struct {
+	latencies map[string]time.Duration
+	errors    map[string]error
+}
+
+func (f *fakeProber) Probe(_ context.Context, line selector.Line) selector.ProbeResult {
+	if err := f.errors[line.ID]; err != nil {
+		return selector.ProbeResult{LineID: line.ID, Err: err}
+	}
+	return selector.ProbeResult{LineID: line.ID, TCPLatency: f.latencies[line.ID]}
+}
+
+// newTestDB 创建内存 SQLite 并迁移 TunService 模型。
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("打开内存数据库失败: %v", err)
+	}
+	if err := db.AutoMigrate(&model.TunService{}); err != nil {
+		t.Fatalf("迁移失败: %v", err)
+	}
+	return db
+}
+
+// newTestManager 构造 Manager：linereg 注入 fake prober 与固定线路。
+func newTestManager(t *testing.T, lines []selector.Line, lat map[string]time.Duration, errs map[string]error) *Manager {
+	t.Helper()
+	db := newTestDB(t)
+	lineregMgr := linereg.NewManager(db, nil, 0)
+	lineregMgr.Selector().SetToolFilter(nil)
+	lineregMgr.Selector().SetLines(lines)
+	lineregMgr.Selector().SetProber(&fakeProber{latencies: lat, errors: errs})
+	return NewManager(db, nil, lineregMgr, nil, nil, nil, nil, nil)
+}
+
+func TestSpeedtestSortsByLatency(t *testing.T) {
+	lines := []selector.Line{
+		{ID: "frp:1", Name: "阿里 frps", Tool: "frp", Address: "1.2.3.4:7000"},
+		{ID: "wg:1", Name: "WG 对端", Tool: "wireguard", Address: "1.2.3.5:51820"},
+		{ID: "nps:1", Name: "nps 节点", Tool: "nps", Address: "5.6.7.8:8024"},
+	}
+	m := newTestManager(t, lines, map[string]time.Duration{
+		"frp:1": 300 * time.Millisecond,
+		"wg:1":  100 * time.Millisecond,
+		"nps:1": 200 * time.Millisecond,
+	}, nil)
+	db := m.db
+	db.Create(&model.TunService{
+		Name:          "SSH 服务",
+		Enable:        true,
+		TargetAddress: "192.168.1.10",
+		TargetPort:    22,
+		Protocol:      "tcp",
+		LineRefs:      `["frp:1","wg:1","nps:1"]`,
+	})
+
+	out, err := m.Speedtest(1)
+	if err != nil {
+		t.Fatalf("Speedtest 失败: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("期望 3 条结果, got %d: %+v", len(out), out)
+	}
+	// 延迟升序：wg(100) < nps(200) < frp(300)
+	want := []string{"wg:1", "nps:1", "frp:1"}
+	for i, id := range want {
+		if out[i].ID != id {
+			t.Errorf("排序错误: 位置 %d 期望 %s, got %s", i, id, out[i].ID)
+		}
+		if out[i].Latency <= 0 {
+			t.Errorf("线路 %s 应有正延迟, got %d", id, out[i].Latency)
+		}
+	}
+}
+
+func TestSpeedtestFailuresLast(t *testing.T) {
+	lines := []selector.Line{
+		{ID: "frp:1", Name: "阿里 frps", Tool: "frp", Address: "1.2.3.4:7000"},
+		{ID: "wg:1", Name: "WG 对端", Tool: "wireguard", Address: "1.2.3.5:51820"},
+	}
+	m := newTestManager(t, lines, map[string]time.Duration{
+		"frp:1": 50 * time.Millisecond,
+	}, map[string]error{
+		"wg:1": errors.New("connect refused"),
+	})
+	db := m.db
+	db.Create(&model.TunService{
+		Name:          "SSH 服务",
+		Enable:        true,
+		TargetAddress: "192.168.1.10",
+		TargetPort:    22,
+		Protocol:      "tcp",
+		LineRefs:      `["frp:1","wg:1"]`,
+	})
+
+	out, err := m.Speedtest(1)
+	if err != nil {
+		t.Fatalf("Speedtest 失败: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("期望 2 条结果, got %d", len(out))
+	}
+	// 成功线路在前，失败线路排最后
+	if out[0].ID != "frp:1" || out[0].Error != "" {
+		t.Errorf("期望成功线路 frp:1 在前, got %+v", out[0])
+	}
+	if out[1].ID != "wg:1" || out[1].Error == "" {
+		t.Errorf("期望失败线路 wg:1 排最后并带错误, got %+v", out[1])
+	}
+}
+
+func TestSpeedtestUnknownService(t *testing.T) {
+	m := newTestManager(t, nil, nil, nil)
+	if _, err := m.Speedtest(999); err == nil {
+		t.Fatal("不存在的服务应返回错误")
+	}
+}

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -121,6 +121,7 @@ export const tunserviceApi = {
   stop: (id: number) => request.post(`/v1/tunservice/${id}/stop`),
   candidates: (id: number) => request.get(`/v1/tunservice/${id}/candidates`),
   history: (id: number, limit = 100) => request.get(`/v1/tunservice/${id}/history?limit=${limit}`),
+  speedtest: (id: number) => request.get(`/v1/tunservice/${id}/speedtest`),
 }
 
 // ===== WireGuard =====

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -471,14 +471,6 @@ export const aiProviderApi = {
   test: (id: number) => request.post(`/v1/ai/providers/${id}/test`),
 }
 
-// ===== 线路探测策略（linereg） =====
-export const lineregApi = {
-  getConfig: () => request.get('/v1/linereg/config'),
-  updateConfig: (data: any) => request.put('/v1/linereg/config', data),
-  rebindPending: () => request.get('/v1/linereg/rebind-pending'),
-  rebindApply: () => request.post('/v1/linereg/rebind-apply'),
-}
-
 // AI 对话
 export const aiChatApi = {
   listConversations: () => request.get('/v1/ai/conversations'),

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -470,6 +470,14 @@ export const aiProviderApi = {
   test: (id: number) => request.post(`/v1/ai/providers/${id}/test`),
 }
 
+// ===== 线路探测策略（linereg） =====
+export const lineregApi = {
+  getConfig: () => request.get('/v1/linereg/config'),
+  updateConfig: (data: any) => request.put('/v1/linereg/config', data),
+  rebindPending: () => request.get('/v1/linereg/rebind-pending'),
+  rebindApply: () => request.post('/v1/linereg/rebind-apply'),
+}
+
 // AI 对话
 export const aiChatApi = {
   listConversations: () => request.get('/v1/ai/conversations'),

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -1604,6 +1604,8 @@ const en = {
     lightTheme: 'Light',
     darkTheme: 'Dark',
     interfaceSettings: 'Interface Settings',
+    speedtestPopup: 'Speed Test Popup',
+    speedtestPopupTip: 'Show ⚡ speed test button on TunService page for instant line probing',
     about: 'About',
   },
   // Tunnel services
@@ -1635,6 +1637,9 @@ const en = {
     rebindPending: 'Pending',
     rebindApply: 'Apply Rebind',
     rebindApplied: 'Rebound {n} service(s)',
+    speedtest: 'Speed Test',
+    speedtestRetest: 'Retest',
+    speedtestDown: 'Unavailable',
     lockLine: 'Lock Line',
     auto: 'Auto',
     saved: 'Saved',

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -1643,6 +1643,8 @@ const zh = {
     lightTheme: '浅色',
     darkTheme: '深色',
     interfaceSettings: '界面设置',
+    speedtestPopup: '测速弹窗',
+    speedtestPopupTip: '开启后 TunService 页面显示 ⚡ 测速按钮，可手动触发线路即时测速',
     about: '关于',
   },
   // 内网穿透管理
@@ -1674,6 +1676,9 @@ const zh = {
     rebindPending: '待重绑',
     rebindApply: '手动重绑',
     rebindApplied: '已重绑 {n} 个服务',
+    speedtest: '测速',
+    speedtestRetest: '重新测速',
+    speedtestDown: '不可用',
     lockLine: '锁定线路',
     auto: '自动',
     saved: '已保存',

--- a/webpage/src/index.css
+++ b/webpage/src/index.css
@@ -204,6 +204,22 @@ body::after {
   }
 }
 
+/* ===== 测速弹窗动画 ===== */
+.speedtest-row {
+  animation: speedtestRowIn 0.35s ease-out backwards;
+}
+
+@keyframes speedtestRowIn {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* ===== 状态标签 ===== */
 .status-running { color: #52c41a; }
 .status-stopped { color: #8c8c8c; }

--- a/webpage/src/pages/Settings.tsx
+++ b/webpage/src/pages/Settings.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
 import {
-  Card, Form, Input, Button, Select, Divider, message,
+  Card, Form, Input, Button, Select, Divider, message, Switch,
   Typography, Row, Col, Space, Tag, Alert,
 } from 'antd'
 import {
   LockOutlined, GlobalOutlined, InfoCircleOutlined,
-  CheckCircleOutlined,
+  CheckCircleOutlined, ThunderboltOutlined,
 } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -25,6 +25,37 @@ const Settings: React.FC = () => {
   const [pwdForm] = Form.useForm()
   const [loading, setLoading] = useState(false)
   const [pwdSuccess, setPwdSuccess] = useState(false)
+  // 测速弹窗开关（SystemConfig: speedtest_popup_enabled，默认开启）
+  const [speedtestEnabled, setSpeedtestEnabled] = useState(true)
+  const [speedtestLoaded, setSpeedtestLoaded] = useState(false)
+
+  // 读取系统配置中的测速弹窗开关
+  const loadSpeedtestSwitch = async () => {
+    try {
+      const res = await systemApi.getConfig()
+      const val = res?.data?.speedtest_popup_enabled
+      if (val !== undefined) {
+        setSpeedtestEnabled(val === 'true' || val === '1')
+      }
+    } catch {
+      // 读取失败保持默认开启
+    }
+  }
+  if (!speedtestLoaded) {
+    setSpeedtestLoaded(true)
+    loadSpeedtestSwitch()
+  }
+
+  const handleSpeedtestSwitch = async (checked: boolean) => {
+    setSpeedtestEnabled(checked)
+    try {
+      await systemApi.updateConfig({ speedtest_popup_enabled: checked ? 'true' : 'false' })
+      message.success(t('settings.saved'))
+    } catch {
+      setSpeedtestEnabled(!checked)
+      message.error(t('common.failed'))
+    }
+  }
 
   const handleChangePassword = async () => {
     const values = await pwdForm.validateFields()
@@ -137,6 +168,19 @@ const Settings: React.FC = () => {
                 <Option value="zh">🇨🇳 中文</Option>
                 <Option value="en">🇺🇸 English</Option>
               </Select>
+            </div>
+
+            <Divider />
+
+            <div>
+              <Text strong style={{ display: 'block', marginBottom: 8 }}>
+                <ThunderboltOutlined style={{ marginRight: 6, color: '#1677ff' }} />
+                {t('settings.speedtestPopup')}
+              </Text>
+              <Space style={{ marginBottom: 4 }}>
+                <Switch checked={speedtestEnabled} onChange={handleSpeedtestSwitch} />
+                <Text type="secondary">{t('settings.speedtestPopupTip')}</Text>
+              </Space>
             </div>
 
             <Divider />

--- a/webpage/src/pages/TunService.tsx
+++ b/webpage/src/pages/TunService.tsx
@@ -25,6 +25,7 @@ import {
     ReloadOutlined,
     StopOutlined,
     SettingOutlined,
+    ThunderboltOutlined,
 } from '@ant-design/icons'
 import {useTranslation} from 'react-i18next'
 import {lineregApi, tunserviceApi} from '../api'
@@ -59,6 +60,10 @@ const TunService: React.FC = () => {
     const [probeOpen, setProbeOpen] = useState(false)
     const [probeLoading, setProbeLoading] = useState(false)
     const [probeForm] = Form.useForm()
+    const [speedtestOpen, setSpeedtestOpen] = useState(false)
+    const [speedtestLoading, setSpeedtestLoading] = useState(false)
+    const [speedtestRow, setSpeedtestRow] = useState<any>(null)
+    const [speedtestData, setSpeedtestData] = useState<any[]>([])
 
     const load = async () => {
         setLoading(true)
@@ -203,6 +208,22 @@ const TunService: React.FC = () => {
         }
     }
 
+    // 测速：对服务关联线路做一次即时并发测速，弹窗展示（延迟升序、失败标红）。
+    const runSpeedtest = async (row: any) => {
+        setSpeedtestRow(row)
+        setSpeedtestOpen(true)
+        setSpeedtestLoading(true)
+        setSpeedtestData([])
+        try {
+            const res = await tunserviceApi.speedtest(row.id)
+            setSpeedtestData(res?.data || [])
+        } catch (e: any) {
+            message.error(e?.response?.data?.message || t('common.failed'))
+        } finally {
+            setSpeedtestLoading(false)
+        }
+    }
+
     const showDetail = async (id: number) => {
         setDetailOpen(true)
         setHistory({})
@@ -315,6 +336,9 @@ const TunService: React.FC = () => {
                             <Button size="small" type="primary" icon={<PlayCircleOutlined/>} onClick={() => start(row.id)}/>
                         </Tooltip>
                     )}
+                    <Tooltip title={t('tunservice.speedtest')}>
+                        <Button size="small" icon={<ThunderboltOutlined/>} onClick={() => runSpeedtest(row)}/>
+                    </Tooltip>
                     <Tooltip title={t('tunservice.detail')}>
                         <Button size="small" onClick={() => showDetail(row.id)}>{t('tunservice.detail')}</Button>
                     </Tooltip>
@@ -440,6 +464,51 @@ const TunService: React.FC = () => {
                         </Button>
                     </Form.Item>
                 </Form>
+            </Modal>
+
+            <Modal
+                title={`${t('tunservice.speedtest')} · ${speedtestRow?.name || ''}`}
+                open={speedtestOpen}
+                onCancel={() => setSpeedtestOpen(false)}
+                footer={[
+                    <Button key="retest" icon={<ThunderboltOutlined/>} loading={speedtestLoading} onClick={() => runSpeedtest(speedtestRow)}>
+                        {t('tunservice.speedtestRetest')}
+                    </Button>,
+                    <Button key="close" type="primary" onClick={() => setSpeedtestOpen(false)}>
+                        {t('common.close')}
+                    </Button>,
+                ]}
+                destroyOnClose
+                width={520}
+            >
+                <Table
+                    rowKey="id"
+                    size="small"
+                    loading={speedtestLoading}
+                    pagination={false}
+                    dataSource={speedtestData}
+                    columns={[
+                        {title: 'ID', dataIndex: 'id', width: 120},
+                        {title: t('common.name'), dataIndex: 'name'},
+                        {
+                            title: t('tunservice.latency'),
+                            dataIndex: 'latency',
+                            width: 110,
+                            render: (v: number, row: any) => {
+                                if (row.error) {
+                                    return <Text type="danger">{t('tunservice.speedtestDown')}</Text>
+                                }
+                                return v > 0 ? <Text strong style={{color: '#faad14'}}>{`${(v / 1e6).toFixed(1)} ms`}</Text> : '-'
+                            },
+                        },
+                        {
+                            title: t('common.status'),
+                            dataIndex: 'error',
+                            width: 90,
+                            render: (v: string) => (v ? <Badge status="error" text={t('tunservice.speedtestDown')}/> : <Badge status="success" text={t('common.normal')}/>),
+                        },
+                    ]}
+                />
             </Modal>
 
             <Drawer


### PR DESCRIPTION
## 功能说明 / Overview

在自动选线（#16）基础上新增用户可感知的测速体验：一键对服务的全部关联线路做即时并发测速，弹窗展示结果（延迟升序、失败标红、可重测）。

Adds a user-visible speed-test experience on top of auto line-selection (#16): one-click instant concurrent probing of all lines of a service, with results shown in a popup (sorted by latency, failures in red, re-testable).

### 后端 / Backend

- selector 新增 `SetProber`（测试注入）与 `ProbeLines`（即时并发测速，**不刷新内部选线状态**/锁线/历史），复用信号量限流
- linereg 新增 `SetProber` 透传
- tunservice 新增 `Speedtest`：按服务 LineRefs 即时并发测速，延迟升序返回、失败线路排最后
- `GET /v1/tunservice/:id/speedtest`，受 SystemConfig 键 `speedtest_popup_enabled` 控制（默认开启；设为 false 时 403）
- db 种子 `FirstOrCreate` 确保 `speedtest_popup_enabled` 键存在

### 前端 / Frontend

- TunService 表格新增 ⚡ 测速按钮 + 测速弹窗（延迟升序、失败标红、支持重新测速），index.css 新增弹窗行进入动画
- Settings 新增「测速弹窗」开关（读/写 `speedtest_popup_enabled`）
- i18n zh/en 补全 speedtest 相关文案

### 测试 / Tests

- selector：`ProbeLines` 不刷新内部状态、ctx 取消返回取消结果
- tunservice：Speedtest 延迟排序、失败排最后、未知服务报错

## 依赖 / Dependencies

- 基于 #16 自动选线主线与本分支之前的 PR 叠放，按依赖顺序合并即可