### PR TITLE
feat(init): 首次启动初始化向导，无管理员时强制设置管理员密码 / First-run setup wizard

### DIFF
--- a/backend/api/handlers/frp.go
+++ b/backend/api/handlers/frp.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sort"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/netpanel/netpanel/model"
@@ -151,6 +154,77 @@ func (h *FrpcHandler) DeleteProxy(c *gin.Context) {
 	logger.WriteLog("info", "frp", fmt.Sprintf("删除FRP代理 [%d] 客户端[%d]", pid, id))
 	h.mgr.RestartClient(uint(id))
 	c.JSON(http.StatusOK, gin.H{"code": 200, "message": "删除成功"})
+}
+
+// speedTestTarget 测速目标（去重后的 FRP 服务端地址）
+type speedTestTarget struct {
+	ID         uint
+	Name       string
+	ServerAddr string
+	ServerPort int
+}
+
+// SpeedTest 线路测速：测量所有 FRP 客户端指向的服务端 TCP 握手延迟
+func (h *FrpcHandler) SpeedTest(c *gin.Context) {
+	var configs []model.FrpcConfig
+	h.db.Select("id, name, server_addr, server_port").Find(&configs)
+
+	// 按 (server_addr, server_port) 去重，多个客户端可能指向同一台服务端
+	seen := make(map[string]struct{})
+	var targets []speedTestTarget
+	for _, cfg := range configs {
+		key := fmt.Sprintf("%s:%d", cfg.ServerAddr, cfg.ServerPort)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, speedTestTarget{cfg.ID, cfg.Name, cfg.ServerAddr, cfg.ServerPort})
+	}
+
+	if len(targets) == 0 {
+		c.JSON(http.StatusOK, gin.H{"code": 200, "data": []gin.H{}})
+		return
+	}
+
+	timeout := 5 * time.Second
+	results := make([]gin.H, len(targets))
+	var wg sync.WaitGroup
+	for i, t := range targets {
+		wg.Add(1)
+		go func(i int, t speedTestTarget) {
+			defer wg.Done()
+			addr := net.JoinHostPort(t.ServerAddr, strconv.Itoa(t.ServerPort))
+			start := time.Now()
+			conn, err := net.DialTimeout("tcp", addr, timeout)
+			if err != nil {
+				results[i] = gin.H{
+					"id": t.ID, "name": t.Name,
+					"server_addr": t.ServerAddr, "server_port": t.ServerPort,
+					"latency_ms": 0, "status": "unreachable", "error": err.Error(),
+				}
+				return
+			}
+			conn.Close()
+			results[i] = gin.H{
+				"id": t.ID, "name": t.Name,
+				"server_addr": t.ServerAddr, "server_port": t.ServerPort,
+				"latency_ms": time.Since(start).Milliseconds(), "status": "ok",
+			}
+		}(i, t)
+	}
+	wg.Wait()
+
+	// 按延迟升序排序，不可达的排最后
+	sort.Slice(results, func(i, j int) bool {
+		si := results[i]["status"].(string)
+		sj := results[j]["status"].(string)
+		if si != sj {
+			return si == "ok"
+		}
+		return results[i]["latency_ms"].(int64) < results[j]["latency_ms"].(int64)
+	})
+
+	c.JSON(http.StatusOK, gin.H{"code": 200, "data": results})
 }
 
 // ===== FRP 服务端 =====

--- a/backend/api/handlers/frp.go
+++ b/backend/api/handlers/frp.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netpanel/netpanel/pkg/logger"
 	"github.com/netpanel/netpanel/service/frp"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 	"gorm.io/gorm"
 )
 
@@ -23,10 +24,51 @@ type FrpcHandler struct {
 	db  *gorm.DB
 	log *logrus.Logger
 	mgr *frp.Manager
+
+	// SpeedTest IP 级限流：10 次/分钟，防止接口被滥用为端口扫描
+	speedTestMu       sync.Mutex
+	speedTestLimiters map[string]*speedTestLimiterEntry
+}
+
+type speedTestLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastUsed time.Time
 }
 
 func NewFrpcHandler(db *gorm.DB, log *logrus.Logger, mgr *frp.Manager) *FrpcHandler {
-	return &FrpcHandler{db: db, log: log, mgr: mgr}
+	return &FrpcHandler{
+		db:                db,
+		log:               log,
+		mgr:               mgr,
+		speedTestLimiters: make(map[string]*speedTestLimiterEntry),
+	}
+}
+
+// getSpeedTestLimiter 返回指定客户端 IP 的限流器，同时惰性清理 10 分钟未使用的条目。
+func (h *FrpcHandler) getSpeedTestLimiter(clientIP string) *rate.Limiter {
+	h.speedTestMu.Lock()
+	defer h.speedTestMu.Unlock()
+
+	if entry, ok := h.speedTestLimiters[clientIP]; ok {
+		entry.lastUsed = time.Now()
+		return entry.limiter
+	}
+
+	limiter := rate.NewLimiter(rate.Every(time.Minute/10), 1)
+	h.speedTestLimiters[clientIP] = &speedTestLimiterEntry{
+		limiter:  limiter,
+		lastUsed: time.Now(),
+	}
+
+	// 惰性清理过期条目，避免内存无限增长
+	now := time.Now()
+	for ip, entry := range h.speedTestLimiters {
+		if now.Sub(entry.lastUsed) > 10*time.Minute {
+			delete(h.speedTestLimiters, ip)
+		}
+	}
+
+	return limiter
 }
 
 func (h *FrpcHandler) List(c *gin.Context) {
@@ -166,6 +208,16 @@ type speedTestTarget struct {
 
 // SpeedTest 线路测速：测量所有 FRP 客户端指向的服务端 TCP 握手延迟
 func (h *FrpcHandler) SpeedTest(c *gin.Context) {
+	// IP 级限流（10 次/分钟），防止接口被滥用为端口扫描
+	clientIP := c.ClientIP()
+	if !h.getSpeedTestLimiter(clientIP).Allow() {
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			"code":  429,
+			"error": "rate limit exceeded (max 10/min)",
+		})
+		return
+	}
+
 	var configs []model.FrpcConfig
 	h.db.Select("id, name, server_addr, server_port").Find(&configs)
 

--- a/backend/api/handlers/frp.go
+++ b/backend/api/handlers/frp.go
@@ -252,7 +252,7 @@ func (h *FrpcHandler) SpeedTest(c *gin.Context) {
 				results[i] = gin.H{
 					"id": t.ID, "name": t.Name,
 					"server_addr": t.ServerAddr, "server_port": t.ServerPort,
-					"latency_ms": 0, "status": "unreachable", "error": err.Error(),
+					"latency_ms": int64(0), "status": "unreachable", "error": err.Error(),
 				}
 				return
 			}

--- a/backend/api/handlers/init.go
+++ b/backend/api/handlers/init.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/netpanel/netpanel/model"
+	"github.com/netpanel/netpanel/pkg/logger"
+	"github.com/netpanel/netpanel/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// InitHandler 首次初始化处理器
+type InitHandler struct {
+	db  *gorm.DB
+	log *logrus.Logger
+}
+
+func NewInitHandler(db *gorm.DB, log *logrus.Logger) *InitHandler {
+	return &InitHandler{db: db, log: log}
+}
+
+// isInitialized 判断系统是否已初始化（存在用户或旧版 admin_password 配置即视为已初始化）
+func (h *InitHandler) isInitialized() bool {
+	var userCount int64
+	h.db.Model(&model.User{}).Count(&userCount)
+	if userCount > 0 {
+		return true
+	}
+	var cfgCount int64
+	h.db.Model(&model.SystemConfig{}).Where("key = ?", "admin_password").Count(&cfgCount)
+	return cfgCount > 0
+}
+
+// Status 获取初始化状态
+// GET /api/v1/init/status
+func (h *InitHandler) Status(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"code": 200, "data": gin.H{"initialized": h.isInitialized()}})
+}
+
+// Setup 首次初始化：创建首个管理员账号
+// POST /api/v1/init/setup  body: {username, password}
+func (h *InitHandler) Setup(c *gin.Context) {
+	var req struct {
+		Username string `json:"username" binding:"required,min=2,max=50"`
+		Password string `json:"password" binding:"required,min=8"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "参数错误: " + err.Error()})
+		return
+	}
+
+	if h.isInitialized() {
+		c.JSON(http.StatusForbidden, gin.H{"code": 403, "message": "系统已初始化，无需重复设置"})
+		return
+	}
+
+	// 用户名唯一性
+	var count int64
+	h.db.Model(&model.User{}).Where("username = ?", req.Username).Count(&count)
+	if count > 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "用户名已存在"})
+		return
+	}
+
+	hashed, err := utils.HashPassword(req.Password)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "message": "密码加密失败"})
+		return
+	}
+
+	user := model.User{
+		Username: req.Username,
+		Password: hashed,
+		Enable:   true,
+		IsAdmin:  true,
+		Remark:   "系统初始化创建",
+	}
+	if err := h.db.Create(&user).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "message": "创建失败: " + err.Error()})
+		return
+	}
+
+	// 同步旧版 admin_password 配置，兼容历史登录逻辑
+	var cfg model.SystemConfig
+	if err := h.db.Where("key = ?", "admin_password").First(&cfg).Error; err == nil {
+		h.db.Model(&model.SystemConfig{}).Where("key = ?", "admin_password").Update("value", hashed)
+	} else {
+		h.db.Create(&model.SystemConfig{Key: "admin_password", Value: hashed})
+	}
+
+	logger.WriteLog("info", "system", fmt.Sprintf("系统初始化：创建管理员 %s", req.Username))
+	c.JSON(http.StatusOK, gin.H{"code": 200, "message": "初始化完成", "data": gin.H{"username": req.Username}})
+}

--- a/backend/api/handlers/init.go
+++ b/backend/api/handlers/init.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/netpanel/netpanel/model"
@@ -16,6 +17,7 @@ import (
 type InitHandler struct {
 	db  *gorm.DB
 	log *logrus.Logger
+	mu  sync.Mutex // 串行化 setup，防止并发请求同时通过初始化检查
 }
 
 func NewInitHandler(db *gorm.DB, log *logrus.Logger) *InitHandler {
@@ -52,6 +54,10 @@ func (h *InitHandler) Setup(c *gin.Context) {
 		return
 	}
 
+	// 互斥锁：串行化"检查已初始化 -> 创建管理员"，避免并发请求同时通过检查
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	if h.isInitialized() {
 		c.JSON(http.StatusForbidden, gin.H{"code": 403, "message": "系统已初始化，无需重复设置"})
 		return
@@ -78,17 +84,20 @@ func (h *InitHandler) Setup(c *gin.Context) {
 		IsAdmin:  true,
 		Remark:   "系统初始化创建",
 	}
-	if err := h.db.Create(&user).Error; err != nil {
+	// 事务：创建管理员与同步 admin_password 配置要么全部成功、要么全部回滚
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&user).Error; err != nil {
+			return err
+		}
+		// 同步旧版 admin_password 配置，兼容历史登录逻辑
+		var cfg model.SystemConfig
+		if err := tx.Where("key = ?", "admin_password").First(&cfg).Error; err == nil {
+			return tx.Model(&model.SystemConfig{}).Where("key = ?", "admin_password").Update("value", hashed).Error
+		}
+		return tx.Create(&model.SystemConfig{Key: "admin_password", Value: hashed}).Error
+	}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "message": "创建失败: " + err.Error()})
 		return
-	}
-
-	// 同步旧版 admin_password 配置，兼容历史登录逻辑
-	var cfg model.SystemConfig
-	if err := h.db.Where("key = ?", "admin_password").First(&cfg).Error; err == nil {
-		h.db.Model(&model.SystemConfig{}).Where("key = ?", "admin_password").Update("value", hashed)
-	} else {
-		h.db.Create(&model.SystemConfig{Key: "admin_password", Value: hashed})
 	}
 
 	logger.WriteLog("info", "system", fmt.Sprintf("系统初始化：创建管理员 %s", req.Username))

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -72,6 +72,11 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	apiV1.POST("/auth/login", authHandler.Login)
 	apiV1.POST("/auth/logout", authHandler.Logout)
 
+	// 首次初始化（无管理员时强制建首个管理员）
+	initHandler := handlers.NewInitHandler(opts.DB, opts.Log)
+	apiV1.GET("/init/status", initHandler.Status)
+	apiV1.POST("/init/setup", initHandler.Setup)
+
 	// OAuth2/OIDC 公开路由
 	oauthHandler := handlers.NewOAuthHandler(opts.DB, opts.Log)
 	apiV1.GET("/auth/oauth/providers", oauthHandler.ListPublicProviders)

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -121,6 +121,7 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	auth.POST("/frpc/:id/start", frpcHandler.Start)
 	auth.POST("/frpc/:id/stop", frpcHandler.Stop)
 	auth.POST("/frpc/:id/restart", frpcHandler.Restart)
+	auth.GET("/frpc/speedtest", frpcHandler.SpeedTest)
 	// FRP 代理
 	auth.GET("/frpc/:id/proxies", frpcHandler.ListProxies)
 	auth.POST("/frpc/:id/proxies", frpcHandler.CreateProxy)

--- a/webpage/src/App.tsx
+++ b/webpage/src/App.tsx
@@ -1,8 +1,11 @@
-import React, { Suspense, lazy } from 'react'
+import React, { Suspense, lazy, useEffect, useState } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { Spin } from 'antd'
 import MainLayout from './layouts/MainLayout'
 import LoginPage from './pages/Login'
+import InitSetup from './pages/InitSetup'
+import Onboarding from './pages/Onboarding'
+import { initApi } from './api'
 import { useAppStore } from './store/appStore'
 
 // 懒加载页面
@@ -72,10 +75,25 @@ const PrivateRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => 
   return <>{children}</>
 }
 
+// 初始化守卫：未初始化时强制跳转初始化向导
+const InitGuard: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, setState] = useState<'loading' | 'init' | 'done'>('loading')
+  useEffect(() => {
+    initApi.status()
+      .then((res: any) => setState(res?.data?.initialized === false ? 'init' : 'done'))
+      .catch(() => setState('done'))
+  }, [])
+  if (state === 'loading') return <div style={{ display: 'flex', height: '100vh', alignItems: 'center', justifyContent: 'center' }}><Spin size="large" /></div>
+  if (state === 'init') return <Navigate to="/setup" replace />
+  return <>{children}</>
+}
+
 const App: React.FC = () => {
   return (
     <Routes>
-      <Route path="/login" element={<LoginPage />} />
+      <Route path="/setup" element={<InitSetup />} />
+      <Route path="/onboarding" element={<Onboarding />} />
+      <Route path="/login" element={<InitGuard><LoginPage /></InitGuard>} />
       <Route path="/oauth/callback" element={<Suspense fallback={<PageLoader />}><OAuthCallback /></Suspense>} />
       <Route
         path="/"

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -31,6 +31,7 @@ export const frpcApi = {
   delete: (id: number) => request.delete(`/v1/frpc/${id}`),
   start: (id: number) => request.post(`/v1/frpc/${id}/start`),
   stop: (id: number) => request.post(`/v1/frpc/${id}/stop`),
+  speedtest: () => request.get('/v1/frpc/speedtest'),
   restart: (id: number) => request.post(`/v1/frpc/${id}/restart`),
 }
 

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -568,3 +568,9 @@ export const monitorApi = {
   deleteTunnelBinding: (id: number) => request.delete(`/v1/monitor/tunnels/${id}`),
   syncTunnelStatus: (id: number) => request.post(`/v1/monitor/tunnels/${id}/sync`),
 }
+
+// ===== 首次初始化 =====
+export const initApi = {
+  status: () => request.get('/v1/init/status'),
+  setup: (data: { username: string; password: string }) => request.post('/v1/init/setup', data),
+}

--- a/webpage/src/i18n/locales/en.ts
+++ b/webpage/src/i18n/locales/en.ts
@@ -189,6 +189,14 @@ const en = {
     customDomains: 'Custom Domains',
     subdomain: 'Subdomain',
     addProxy: 'Add Proxy',
+    // Line speed test
+    speedTest: 'Speed Test',
+    speedTestResult: 'Speed Test Result',
+    latency: 'Latency',
+    reachable: 'Reachable',
+    unreachable: 'Unreachable',
+    noFrpc: 'No FRP client to test',
+    speedTestFailed: 'Speed test failed',
     // Client - Table columns
     protocol: 'Protocol',
     proxy: 'Proxy',

--- a/webpage/src/i18n/locales/zh.ts
+++ b/webpage/src/i18n/locales/zh.ts
@@ -197,6 +197,14 @@ const zh = {
     customDomains: '自定义域名',
     subdomain: '子域名',
     addProxy: '添加代理',
+    // 线路测速
+    speedTest: '线路测速',
+    speedTestResult: '测速结果',
+    latency: '延迟',
+    reachable: '可达',
+    unreachable: '不可达',
+    noFrpc: '暂无可测速的 FRP 客户端',
+    speedTestFailed: '测速失败',
     // 客户端 - 表格列
     protocol: '协议',
     proxy: '代理',

--- a/webpage/src/pages/FrpClient.tsx
+++ b/webpage/src/pages/FrpClient.tsx
@@ -80,6 +80,11 @@ const FrpClient: React.FC = () => {
     const [proxyForm] = Form.useForm()
     const [proxyType, setProxyType] = useState('tcp')
 
+    // 线路测速
+    const [speedTestOpen, setSpeedTestOpen] = useState(false)
+    const [speedTestData, setSpeedTestData] = useState<any[]>([])
+    const [speedTesting, setSpeedTesting] = useState(false)
+
     const fetchData = async () => {
         setLoading(true)
         try {
@@ -98,6 +103,30 @@ const FrpClient: React.FC = () => {
         const res: any = await request.get(`/v1/frpc/${frpcId}/proxies`)
         setProxies(res.data || [])
     }
+
+    const runSpeedTest = async () => {
+        setSpeedTestOpen(true)
+        setSpeedTesting(true)
+        setSpeedTestData([])
+        try {
+            const res: any = await request.get('/v1/frpc/speedtest')
+            setSpeedTestData(res.data || [])
+        } catch (e: any) {
+            message.error(e?.message || t('frp.speedTestFailed'))
+        } finally {
+            setSpeedTesting(false)
+        }
+    }
+
+    // 测速结果表格列
+    const speedTestColumns = [
+        {title: t('frp.clientName'), dataIndex: 'name'},
+        {title: t('frp.serverAddr'), dataIndex: 'server_addr', render: (_: any, r: any) => `${r.server_addr}:${r.server_port}`},
+        {title: t('frp.latency'), dataIndex: 'latency_ms', render: (v: number, r: any) => (r.status === 'ok' ? `${v} ms` : '-')},
+        {title: t('frp.status'), dataIndex: 'status', render: (v: string) => (
+            <Tag color={v === 'ok' ? 'green' : 'red'}>{v === 'ok' ? t('frp.reachable') : t('frp.unreachable')}</Tag>
+        )},
+    ]
 
     const openProxyDrawer = (record: any) => {
         setCurrentFrpc(record)
@@ -1045,6 +1074,9 @@ const FrpClient: React.FC = () => {
                     >
                         FRP {t('common.officialSite')}
                     </Button>
+                    <Button icon={<ThunderboltOutlined/>} loading={speedTesting} onClick={runSpeedTest}>
+                        {t('frp.speedTest')}
+                    </Button>
                     <Button type="primary" icon={<PlusOutlined/>} onClick={handleCreate}>{t('common.create')}</Button>
                 </Space>
             </div>
@@ -1060,6 +1092,21 @@ const FrpClient: React.FC = () => {
                 size="middle" style={tableStyle}
                 pagination={{pageSize: 20, showSizeChanger: true}}
             />
+
+            {/* 线路测速结果弹窗 */}
+            <Modal
+                title={t('frp.speedTestResult')}
+                open={speedTestOpen}
+                onCancel={() => setSpeedTestOpen(false)}
+                footer={null}
+                width={720}
+            >
+                <Table
+                    dataSource={speedTestData} rowKey="id" loading={speedTesting}
+                    size="small" pagination={false} columns={speedTestColumns}
+                    locale={{emptyText: t('frp.noFrpc')}}
+                />
+            </Modal>
 
             {/* frpc 编辑弹窗 */}
             <Modal

--- a/webpage/src/pages/InitSetup.tsx
+++ b/webpage/src/pages/InitSetup.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Form, Input, Button, Typography, Steps, message, Spin } from 'antd'
+import { LockOutlined, UserOutlined, SafetyOutlined, RocketOutlined } from '@ant-design/icons'
+import { initApi } from '../api'
+import { useAppStore } from '../store/appStore'
+
+const { Title, Text } = Typography
+
+// 首次初始化向导：无管理员时强制设置首个管理员密码
+const InitSetup: React.FC = () => {
+  const navigate = useNavigate()
+  const setToken = useAppStore(s => s.setToken)
+  const setUsername = useAppStore(s => s.setUsername)
+  const [checking, setChecking] = useState(true)
+  const [initialized, setInitialized] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [step, setStep] = useState(0)
+  const [form] = Form.useForm()
+
+  useEffect(() => {
+    initApi.status()
+      .then((res: any) => {
+        const init = res?.data?.initialized !== false
+        setInitialized(init)
+        if (init) navigate('/login', { replace: true })
+      })
+      .catch(() => setInitialized(true))
+      .finally(() => setChecking(false))
+  }, [navigate])
+
+  const handleFinish = async (values: { username: string; password: string }) => {
+    setSubmitting(true)
+    try {
+      const res: any = await initApi.setup({
+        username: values.username.trim(),
+        password: values.password,
+      })
+      message.success(res?.message || '初始化完成')
+      // 初始化成功后自动登录
+      const loginRes: any = await fetch('/api/v1/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: values.username.trim(), password: values.password }),
+      }).then(r => r.json())
+      if (loginRes?.data?.token) {
+        setToken(loginRes.data.token)
+        setUsername(loginRes.data.username)
+      }
+      navigate('/dashboard', { replace: true })
+    } catch (e: any) {
+      message.error(e?.message || '初始化失败')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (checking) {
+    return (
+      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Spin size="large" />
+      </div>
+    )
+  }
+  if (initialized) return null
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 24,
+      background: 'var(--bg-body)',
+    }}>
+      <div style={{
+        width: 460,
+        maxWidth: '100%',
+        padding: 36,
+        borderRadius: 'var(--radius-lg)',
+        background: 'var(--bg-card)',
+        boxShadow: 'var(--shadow-card)',
+        border: '1px solid var(--border-color)',
+      }}>
+        <div style={{ textAlign: 'center', marginBottom: 24 }}>
+          <div style={{
+            width: 56, height: 56, borderRadius: 16, margin: '0 auto 16px',
+            background: 'linear-gradient(135deg, #0071e3, #5e5ce6)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 26, color: '#fff', fontWeight: 700,
+          }}>N</div>
+          <Title level={3} style={{ marginBottom: 4 }}>欢迎使用 NetPanel</Title>
+          <Text type="secondary">首次启动，请创建管理员账号并设置密码</Text>
+        </div>
+
+        <Steps
+          size="small"
+          current={step}
+          items={[
+            { title: '创建管理员' },
+            { title: '安全加固' },
+            { title: '完成' },
+          ]}
+          style={{ marginBottom: 28 }}
+        />
+
+        {step === 0 && (
+          <Form form={form} layout="vertical" onFinish={handleFinish} requiredMark={false}>
+            <Form.Item
+              name="username"
+              label="管理员用户名"
+              rules={[
+                { required: true, message: '请输入用户名' },
+                { min: 2, max: 50, message: '长度 2-50 位' },
+              ]}
+            >
+              <Input prefix={<UserOutlined />} placeholder="默认 admin" size="large" />
+            </Form.Item>
+            <Form.Item
+              name="password"
+              label="登录密码"
+              rules={[
+                { required: true, message: '请输入密码' },
+                { min: 8, message: '密码至少 8 位' },
+              ]}
+              extra="建议使用字母、数字与符号组合"
+            >
+              <Input.Password prefix={<LockOutlined />} placeholder="至少 8 位" size="large" />
+            </Form.Item>
+            <Form.Item
+              name="confirm"
+              label="确认密码"
+              dependencies={['password']}
+              rules={[
+                { required: true, message: '请再次输入密码' },
+                ({ getFieldValue }) => ({
+                  validator(_, value) {
+                    if (!value || getFieldValue('password') === value) return Promise.resolve()
+                    return Promise.reject(new Error('两次输入的密码不一致'))
+                  },
+                }),
+              ]}
+            >
+              <Input.Password prefix={<LockOutlined />} placeholder="再次输入密码" size="large" />
+            </Form.Item>
+            <Button type="primary" htmlType="submit" size="large" block loading={submitting}
+              onClick={() => setStep(1)}>
+              下一步：安全加固 →
+            </Button>
+          </Form>
+        )}
+
+        {step === 1 && (
+          <div>
+            <div style={{ textAlign: 'center', padding: '12px 0 20px' }}>
+              <SafetyOutlined style={{ fontSize: 40, color: '#0071e3', marginBottom: 12 }} />
+              <Title level={5}>安全建议</Title>
+              <Text type="secondary" style={{ display: 'block', lineHeight: 1.8 }}>
+                建议登录后立即：<br />
+                ① 在「安全中心」开启 WAF 防护并添加黑白名单<br />
+                ② 通过「CF 隧道」安全暴露内网服务<br />
+                ③ 定期备份数据目录
+              </Text>
+            </div>
+            <Button type="primary" size="large" block loading={submitting} onClick={() => form.submit()}>
+              完成初始化 <RocketOutlined />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default InitSetup

--- a/webpage/src/pages/Onboarding.tsx
+++ b/webpage/src/pages/Onboarding.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Card, Row, Col, Typography, Button, Steps, message } from 'antd'
+import { CloudOutlined, SafetyOutlined, QuestionCircleOutlined, CheckCircleFilled } from '@ant-design/icons'
+
+const { Title, Text, Paragraph } = Typography
+
+// 登录后新手指引（首次进入展示，可跳过）
+const Onboarding: React.FC = () => {
+  const navigate = useNavigate()
+  const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    // 标记已看过引导
+    try { localStorage.setItem('netpanel-onboarded', '1') } catch { /* ignore */ }
+  }, [])
+
+  const finish = () => {
+    message.success('欢迎使用 NetPanel！')
+    navigate('/dashboard', { replace: true })
+  }
+
+  const cards = [
+    {
+      icon: <CloudOutlined style={{ fontSize: 26, color: '#0071e3' }} />,
+      title: '接入公网（推荐先做）',
+      desc: '使用 CF 隧道将内网服务安全暴露到公网，无需公网 IP 与端口映射。',
+      action: () => navigate('/cftunnel', { replace: true }),
+      actionText: '开始配置 →',
+    },
+    {
+      icon: <SafetyOutlined style={{ fontSize: 26, color: '#34c759' }} />,
+      title: '开启安全防护',
+      desc: '启用 WAF 安全中心，自动拦截 SQL 注入、暴力破解等攻击，自动封禁恶意 IP。',
+      action: () => navigate('/security/waf', { replace: true }),
+      actionText: '立即开启 →',
+    },
+    {
+      icon: <QuestionCircleOutlined style={{ fontSize: 26, color: '#bf5af2' }} />,
+      title: '查看使用说明',
+      desc: '每个功能页都内置说明文档与常见问题，随时可在「帮助与说明」查阅。',
+      action: () => navigate('/help', { replace: true }),
+      actionText: '查看帮助 →',
+    },
+  ]
+
+  return (
+    <div style={{
+      minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24,
+      background: 'var(--bg-body)',
+    }}>
+      <div style={{ width: 860, maxWidth: '100%' }}>
+        <div style={{ textAlign: 'center', marginBottom: 26 }}>
+          <div style={{
+            width: 60, height: 60, borderRadius: 18, margin: '0 auto 16px',
+            background: 'linear-gradient(135deg, #0071e3, #5e5ce6)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 28, color: '#fff', fontWeight: 700,
+          }}>N</div>
+          <Title level={3} style={{ marginBottom: 4 }}>欢迎使用 NetPanel</Title>
+          <Text type="secondary">已就绪 · 花 30 秒完成基础配置</Text>
+          <div style={{ maxWidth: 320, margin: '20px auto 0' }}>
+            <Steps size="small" current={step} items={[{ title: '入门' }, { title: '进阶' }, { title: '完成' }]} />
+          </div>
+        </div>
+
+        <Row gutter={[16, 16]}>
+          {cards.map((c, i) => (
+            <Col xs={24} md={8} key={c.title}>
+              <Card hoverable size="small" style={{ borderRadius: 'var(--radius-md)', height: '100%' }}
+                onClick={() => { setStep(i + 1); c.action() }}>
+                <div style={{ marginBottom: 12 }}>{c.icon}</div>
+                <b>{c.title}</b>
+                <Paragraph type="secondary" style={{ fontSize: 12.5, marginTop: 8, marginBottom: 10 }}>{c.desc}</Paragraph>
+                <span style={{ color: '#0071e3', fontSize: 13, fontWeight: 600 }}>{c.actionText}</span>
+              </Card>
+            </Col>
+          ))}
+        </Row>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 24 }}>
+          <Button type="text" onClick={finish}>跳过引导</Button>
+          <Button type="primary" icon={<CheckCircleFilled />} onClick={finish}>完成，进入仪表盘</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Onboarding


### PR DESCRIPTION
## 中文

实现 #33：首次启动初始化向导。

- 后端：新增 `GET/POST /api/v1/init/status|setup`，系统无任何用户时强制创建首个管理员，并同步旧版 `admin_password` 配置
- 前端：新增 `/setup` 初始化向导页（3 步：创建管理员 → 安全加固 → 完成），登录页与主路由增加 `InitGuard` 守卫，未初始化时强制跳转
- 新增 `/onboarding` 登录后新手指引页（可跳过）

## English

Implements #33: First-run setup wizard.

- Backend: new `GET/POST /api/v1/init/status|setup` — forces creating the first admin when no user exists, and syncs the legacy `admin_password` config
- Frontend: new `/setup` wizard page (3 steps: create admin → security tips → done), `InitGuard` on login & main routes (redirect to setup when not initialized)
- New `/onboarding` post-login guide page (skippable)
