### PR TITLE
feat(users): 用户管理增强：最后管理员保护 + 管理员改名 / User mgmt: last-admin protection + rename

### DIFF
--- a/backend/api/handlers/admin.go
+++ b/backend/api/handlers/admin.go
@@ -192,6 +192,7 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 	currentUsername, _ := currentUser.(string)
 
 	var req struct {
+		Username string `json:"username"` // 为空则不修改（支持改名）
 		Password string `json:"password"` // 为空则不修改
 		Email    string `json:"email"`
 		Enable   *bool  `json:"enable"`
@@ -209,9 +210,33 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 		return
 	}
 
-	// admin 用户不允许修改 is_admin 字段（防止自我降权）
-	if user.Username == "admin" && req.IsAdmin != nil && !*req.IsAdmin {
-		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "admin 用户不允许取消管理员权限"})
+	updates := map[string]interface{}{
+		"email":  req.Email,
+		"remark": req.Remark,
+	}
+
+	// 改名：内置 admin 不允许改名；新用户名需唯一
+	if req.Username != "" && req.Username != user.Username {
+		if len(req.Username) < 2 || len(req.Username) > 50 {
+			c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "用户名长度需在 2-50 之间"})
+			return
+		}
+		if user.Username == "admin" {
+			c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "内置 admin 账号不允许改名"})
+			return
+		}
+		var dup int64
+		h.db.Model(&model.User{}).Where("username = ? AND id <> ?", req.Username, user.ID).Count(&dup)
+		if dup > 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "用户名已存在"})
+			return
+		}
+		updates["username"] = req.Username
+	}
+
+	// 当前操作者不能修改自己的 is_admin（防止自我降权）
+	if currentUsername == user.Username && req.IsAdmin != nil && !*req.IsAdmin {
+		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "不能取消自己的管理员权限"})
 		return
 	}
 
@@ -219,11 +244,6 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 	if currentUsername != "admin" && req.IsAdmin != nil {
 		c.JSON(http.StatusForbidden, gin.H{"code": 403, "message": "只有 admin 可以修改管理员权限"})
 		return
-	}
-
-	updates := map[string]interface{}{
-		"email":  req.Email,
-		"remark": req.Remark,
 	}
 	if req.Enable != nil {
 		// admin 用户不允许被禁用
@@ -276,6 +296,16 @@ func (h *UserHandler) DeleteUser(c *gin.Context) {
 	if user.Username == "admin" {
 		c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "admin 用户不允许删除"})
 		return
+	}
+
+	// 最后一名启用管理员不允许删除
+	if user.IsAdmin && user.Enable {
+		var adminCount int64
+		h.db.Model(&model.User{}).Where("is_admin = ? AND enable = ?", true, true).Count(&adminCount)
+		if adminCount <= 1 {
+			c.JSON(http.StatusBadRequest, gin.H{"code": 400, "message": "系统必须保留至少一名启用的管理员，不能删除最后一名管理员"})
+			return
+		}
 	}
 
 	h.db.Delete(&model.User{}, id)

--- a/webpage/src/pages/UserManagement.tsx
+++ b/webpage/src/pages/UserManagement.tsx
@@ -66,6 +66,7 @@ const UserManagement: React.FC = () => {
   const openEdit = (user: UserItem) => {
     setEditingUser(user)
     form.setFieldsValue({
+      username: user.username,
       email: user.email,
       enable: user.enable,
       is_admin: user.is_admin,
@@ -86,6 +87,10 @@ const UserManagement: React.FC = () => {
           enable: values.enable,
           is_admin: values.is_admin,
           remark: values.remark,
+        }
+        // 改名（非内置 admin 且发生变化时提交）
+        if (values.username && values.username !== editingUser.username && editingUser.username !== 'admin') {
+          payload.username = values.username
         }
         if (values.password) payload.password = values.password
         await adminApi.updateUser(editingUser.id, payload)
@@ -123,6 +128,10 @@ const UserManagement: React.FC = () => {
     }
   }
 
+  // 最后一个启用管理员不可删除（前端保护，后端同样校验）
+  const enabledAdminCount = users.filter(u => u.is_admin && u.enable).length
+  const isLastAdmin = (record: UserItem) => record.is_admin && record.enable && enabledAdminCount <= 1
+
   const columns: ColumnsType<UserItem> = [
     {
       title: '用户',
@@ -135,7 +144,7 @@ const UserManagement: React.FC = () => {
             style={{
               background: record.is_admin
                 ? 'linear-gradient(135deg, #f5a623, #f76b1c)'
-                : 'linear-gradient(135deg, #1677ff, #0958d9)',
+                : 'linear-gradient(135deg, #0071e3, #0958d9)',
               flexShrink: 0,
             }}
             icon={record.is_admin ? <CrownOutlined /> : <UserOutlined />}
@@ -218,14 +227,16 @@ const UserManagement: React.FC = () => {
           </Tooltip>
           {record.username !== 'admin' && (
             <Popconfirm
-              title="确定要删除该用户吗？"
+              title={isLastAdmin(record) ? '系统必须保留至少一名启用的管理员' : '确定要删除该用户吗？'}
               onConfirm={() => handleDelete(record.id)}
-              okText="删除"
-              okButtonProps={{ danger: true }}
+              okText={isLastAdmin(record) ? '知道了' : '删除'}
+              okButtonProps={isLastAdmin(record) ? { danger: true } : { danger: true }}
               cancelText="取消"
+              onCancel={(e) => { if (isLastAdmin(record)) e?.stopPropagation() }}
             >
-              <Tooltip title="删除">
-                <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+              <Tooltip title={isLastAdmin(record) ? '最后一名管理员不可删除' : '删除'}>
+                <Button type="text" size="small" danger icon={<DeleteOutlined />}
+                  disabled={isLastAdmin(record)} />
               </Tooltip>
             </Popconfirm>
           )}
@@ -239,9 +250,9 @@ const UserManagement: React.FC = () => {
       <Card
         title={
           <Space>
-            <TeamOutlined style={{ color: '#1677ff' }} />
+            <TeamOutlined style={{ color: '#0071e3' }} />
             <span>用户管理</span>
-            <Badge count={users.length} style={{ backgroundColor: '#1677ff' }} />
+            <Badge count={users.length} style={{ backgroundColor: '#0071e3' }} />
           </Space>
         }
         extra={
@@ -260,13 +271,13 @@ const UserManagement: React.FC = () => {
         <div style={{
           marginBottom: 12,
           padding: '8px 12px',
-          background: 'rgba(22,119,255,0.06)',
+          background: 'rgba(0,113,227,0.06)',
           borderRadius: 6,
-          border: '1px solid rgba(22,119,255,0.15)',
+          border: '1px solid rgba(0,113,227,0.15)',
           fontSize: 12,
           color: '#666',
         }}>
-          <UserOutlined style={{ marginRight: 6, color: '#1677ff' }} />
+          <UserOutlined style={{ marginRight: 6, color: '#0071e3' }} />
           admin 为内置超级管理员，不可删除、不可禁用、不可取消管理员权限。
           {!isCurrentAdmin && ' 只有 admin 可以修改用户的管理员权限。'}
         </div>


### PR DESCRIPTION
## 中文

实现 #34：用户管理增强。

- **最后管理员保护**：删除用户时若目标为启用的最后一名管理员则拒绝（前后端双重校验），避免管理面板失控
- **管理员改名**：`UpdateUser` 支持修改用户名（内置 admin 除外，防重名校验），改名不影响登录
- 前端：编辑弹窗支持改名，最后一名管理员删除按钮禁用并提示原因

## English

Implements #34: User management enhancements.

- **Last-admin protection**: deleting the last enabled admin is rejected (validated on both frontend and backend) to avoid losing panel control
- **Admin rename**: `UpdateUser` supports changing username (except built-in `admin`, with uniqueness check); login unaffected
- Frontend: edit dialog supports rename; delete button disabled with tooltip for the last admin
