### PR TITLE
fix: IPv6 地址拼接 vet 报错修复 + 移除重复模型注册 / Fix go vet IPv6 address-format warnings + duplicate model registration

### DIFF
--- a/backend/model/db.go
+++ b/backend/model/db.go
@@ -95,7 +95,7 @@ func autoMigrate(db *gorm.DB) error {
 		&OAuthProviderConfig{},
 		&IPDBSubscription{},
 		&WireguardConfig{},
-		&WireguardPeer{}, WireguardPeer{},
+		&WireguardPeer{},
 		&MeshNode{},
 		&MeshNodeEvent{},
 		// AI 管理模块

--- a/backend/service/monitor/collector.go
+++ b/backend/service/monitor/collector.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -320,7 +321,7 @@ func (c *Collector) ProbeHTTP(probeURL string, timeout int) (bool, int64, int, e
 
 // ProbeTCP TCP 探测
 func (c *Collector) ProbeTCP(addr string, port int, timeout int) (bool, int64, error) {
-	target := fmt.Sprintf("%s:%d", addr, port)
+	target := net.JoinHostPort(addr, strconv.Itoa(port))
 	
 	start := time.Now()
 	conn, err := net.DialTimeout("tcp", target, time.Duration(timeout)*time.Second)
@@ -336,7 +337,7 @@ func (c *Collector) ProbeTCP(addr string, port int, timeout int) (bool, int64, e
 
 // ProbeUDP UDP 探测
 func (c *Collector) ProbeUDP(addr string, port int, timeout int) (bool, int64, error) {
-	target := fmt.Sprintf("%s:%d", addr, port)
+	target := net.JoinHostPort(addr, strconv.Itoa(port))
 	
 	start := time.Now()
 	conn, err := net.DialTimeout("udp", target, time.Duration(timeout)*time.Second)

--- a/backend/service/portforward/manager.go
+++ b/backend/service/portforward/manager.go
@@ -3,6 +3,7 @@ package portforward
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -124,7 +125,7 @@ func (p *TCPProxy) handleConn(src net.Conn) {
 		src.Close()
 	}()
 
-	dst, err := net.Dial("tcp", fmt.Sprintf("%s:%d", p.targetAddr, p.targetPort))
+	dst, err := net.Dial("tcp", net.JoinHostPort(p.targetAddr, strconv.Itoa(p.targetPort)))
 	if err != nil {
 		p.log.Errorf("连接目标[TCP] %s:%d 失败: %v", p.targetAddr, p.targetPort, err)
 		return

--- a/backend/service/portforward/socks5_proxy.go
+++ b/backend/service/portforward/socks5_proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -185,7 +186,7 @@ func (p *SOCKS5Proxy) handleConn(conn net.Conn) {
 		return
 	}
 	targetPort := binary.BigEndian.Uint16(portBuf)
-	fullTarget := fmt.Sprintf("%s:%d", targetAddr, targetPort)
+	fullTarget := net.JoinHostPort(targetAddr, strconv.Itoa(int(targetPort)))
 
 	// 目前只支持 CONNECT（TCP 代理）
 	if cmd != 0x01 {


### PR DESCRIPTION
## 中文

接续 #20（cert/wireguard 的 vet 修复），清理上游 main 上剩余的 4 处 `go vet` IPv6 地址格式告警。目标地址可能是 IPv6 主机名/地址，`fmt.Sprintf("%s:%d")` 拼接会生成非法地址（如 `::1:8080`），统一改用 `net.JoinHostPort`：

| 位置 | 问题 |
|---|---|
| `backend/service/portforward/manager.go:127` | TCP 转发目标地址拼接 |
| `backend/service/portforward/socks5_proxy.go:188` | SOCKS5 CONNECT 目标地址拼接 |
| `backend/service/monitor/collector.go:323` | ProbeTCP 目标拼接 |
| `backend/service/monitor/collector.go:339` | ProbeUDP 目标拼接 |

另外顺手移除 `backend/model/db.go` autoMigrate 里手误重复注册的 `&WireguardPeer{}`（重复注册无副作用，但属于明显笔误）。

### 验证
- `go build ./...` 通过
- `go vet ./...` **0 告警**（修复前 4 处）
- 最小改动，无行为变化（IPv4 路径 JoinHostPort 输出与原拼接一致）

---

## English

Follow-up to #20 (cert/wireguard vet fixes), addressing the remaining 4 `go vet` IPv6 address-format warnings on main. Targets may be IPv6 hosts, where `fmt.Sprintf("%s:%d")` produces invalid addresses; all replaced with `net.JoinHostPort` (TCP forward, SOCKS5 CONNECT, ProbeTCP, ProbeUDP). Also drops a duplicated `&WireguardPeer{}` registration in `autoMigrate`.

Verified: `go build` passes and `go vet ./...` is now warning-free; behavior for IPv4 targets is unchanged.