### PR TITLE
fix(monitor): 接通探测失败告警链路 — 实现 probe 类型告警规则与通知 / Wire probe failure alerts: implement probe-type alert rules

### DIFF
--- a/backend/model/db.go
+++ b/backend/model/db.go
@@ -95,7 +95,7 @@ func autoMigrate(db *gorm.DB) error {
 		&OAuthProviderConfig{},
 		&IPDBSubscription{},
 		&WireguardConfig{},
-		&WireguardPeer{}, WireguardPeer{},
+		&WireguardPeer{},
 		&MeshNode{},
 		&MeshNodeEvent{},
 		// AI 管理模块

--- a/backend/service/monitor/alert.go
+++ b/backend/service/monitor/alert.go
@@ -17,11 +17,11 @@ import (
 type AlertEngine struct {
 	db      *gorm.DB
 	manager *Manager
-	
+
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
-	
+
 	// 告警状态缓存
 	alertStates sync.Map // key: "alert_id:server_id", value: *AlertState
 }
@@ -31,7 +31,7 @@ type AlertState struct {
 	AlertID         uint
 	ServerID        uint
 	IsTriggered     bool
-	TriggerCount    int       // 连续触发次数
+	TriggerCount    int // 连续触发次数
 	LastTriggerTime time.Time
 	LastNotifyTime  time.Time
 	RecordID        uint // 当前告警记录 ID
@@ -48,7 +48,7 @@ type ThresholdConfig struct {
 // NewAlertEngine 创建告警引擎
 func NewAlertEngine(db *gorm.DB, manager *Manager) *AlertEngine {
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	return &AlertEngine{
 		db:      db,
 		manager: manager,
@@ -60,31 +60,31 @@ func NewAlertEngine(db *gorm.DB, manager *Manager) *AlertEngine {
 // Start 启动告警引擎
 func (a *AlertEngine) Start() {
 	log.Println("[AlertEngine] 启动告警引擎...")
-	
+
 	// 启动告警检查协程
 	a.wg.Add(1)
 	go a.alertChecker()
-	
+
 	log.Println("[AlertEngine] 告警引擎启动完成")
 }
 
 // Stop 停止告警引擎
 func (a *AlertEngine) Stop() {
 	log.Println("[AlertEngine] 停止告警引擎...")
-	
+
 	a.cancel()
 	a.wg.Wait()
-	
+
 	log.Println("[AlertEngine] 告警引擎已停止")
 }
 
 // alertChecker 告警检查器
 func (a *AlertEngine) alertChecker() {
 	defer a.wg.Done()
-	
+
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
-	
+
 	for {
 		select {
 		case <-a.ctx.Done():
@@ -99,7 +99,7 @@ func (a *AlertEngine) alertChecker() {
 func (a *AlertEngine) checkAlerts() {
 	var alerts []model.MonitorAlert
 	a.db.Where("enable = ?", true).Find(&alerts)
-	
+
 	for _, alert := range alerts {
 		a.checkAlert(alert)
 	}
@@ -107,16 +107,22 @@ func (a *AlertEngine) checkAlerts() {
 
 // checkAlert 检查单个告警规则
 func (a *AlertEngine) checkAlert(alert model.MonitorAlert) {
+	// 探测失败告警：目标为探测配置（probe:N），按（探测×执行服务器）组合评估
+	if alert.AlertType == "probe" {
+		a.checkProbeAlert(alert)
+		return
+	}
+
 	// 解析目标服务器
 	var targets []string
 	if err := json.Unmarshal([]byte(alert.TargetServers), &targets); err != nil {
 		log.Printf("[AlertEngine] 解析目标服务器失败: %v\n", err)
 		return
 	}
-	
+
 	// 获取目标服务器列表
 	serverIDs := a.resolveTargets(targets)
-	
+
 	// 检查每个服务器
 	for _, serverID := range serverIDs {
 		a.checkServerAlert(alert, serverID)
@@ -126,11 +132,11 @@ func (a *AlertEngine) checkAlert(alert model.MonitorAlert) {
 // resolveTargets 解析目标服务器
 func (a *AlertEngine) resolveTargets(targets []string) []uint {
 	var serverIDs []uint
-	
+
 	for _, target := range targets {
 		var id uint
 		var groupName string
-		
+
 		// 解析目标：server:1 或 group:default
 		if _, err := fmt.Sscanf(target, "server:%d", &id); err == nil {
 			serverIDs = append(serverIDs, id)
@@ -143,7 +149,7 @@ func (a *AlertEngine) resolveTargets(targets []string) []uint {
 			}
 		}
 	}
-	
+
 	return serverIDs
 }
 
@@ -155,11 +161,11 @@ func (a *AlertEngine) checkServerAlert(alert model.MonitorAlert, serverID uint) 
 		log.Printf("[AlertEngine] 解析阈值配置失败: %v\n", err)
 		return
 	}
-	
+
 	// 根据告警类型检查
 	triggered := false
 	var alertContent string
-	
+
 	switch alert.AlertType {
 	case "cpu":
 		triggered, alertContent = a.checkCPUAlert(serverID, config)
@@ -174,9 +180,13 @@ func (a *AlertEngine) checkServerAlert(alert model.MonitorAlert, serverID uint) 
 	case "offline":
 		triggered, alertContent = a.checkOfflineAlert(serverID)
 	}
-	
+
 	// 处理告警状态
-	a.handleAlertState(alert, serverID, triggered, alertContent)
+	event := "recover"
+	if triggered {
+		event = "trigger"
+	}
+	a.handleAlertState(alert, alertTarget{kind: "server", targetID: serverID}, event, alertContent)
 }
 
 // checkCPUAlert 检查 CPU 告警
@@ -185,11 +195,11 @@ func (a *AlertEngine) checkCPUAlert(serverID uint, config ThresholdConfig) (bool
 	if err != nil {
 		return false, ""
 	}
-	
+
 	if a.compareValue(metric.CPUUsage, config.Operator, config.Value) {
 		return true, fmt.Sprintf("CPU 使用率 %.2f%% %s %.2f%%", metric.CPUUsage, a.operatorText(config.Operator), config.Value)
 	}
-	
+
 	return false, ""
 }
 
@@ -199,11 +209,11 @@ func (a *AlertEngine) checkMemoryAlert(serverID uint, config ThresholdConfig) (b
 	if err != nil {
 		return false, ""
 	}
-	
+
 	if a.compareValue(metric.MemUsage, config.Operator, config.Value) {
 		return true, fmt.Sprintf("内存使用率 %.2f%% %s %.2f%%", metric.MemUsage, a.operatorText(config.Operator), config.Value)
 	}
-	
+
 	return false, ""
 }
 
@@ -213,11 +223,11 @@ func (a *AlertEngine) checkDiskAlert(serverID uint, config ThresholdConfig) (boo
 	if err != nil {
 		return false, ""
 	}
-	
+
 	if a.compareValue(metric.DiskUsage, config.Operator, config.Value) {
 		return true, fmt.Sprintf("硬盘使用率 %.2f%% %s %.2f%%", metric.DiskUsage, a.operatorText(config.Operator), config.Value)
 	}
-	
+
 	return false, ""
 }
 
@@ -227,12 +237,12 @@ func (a *AlertEngine) checkNetworkAlert(serverID uint, config ThresholdConfig) (
 	if err != nil {
 		return false, ""
 	}
-	
+
 	totalTraffic := float64(metric.NetSent + metric.NetRecv)
 	if a.compareValue(totalTraffic, config.Operator, config.Value) {
 		return true, fmt.Sprintf("网络流量 %.2f bytes/s %s %.2f", totalTraffic, a.operatorText(config.Operator), config.Value)
 	}
-	
+
 	return false, ""
 }
 
@@ -242,11 +252,11 @@ func (a *AlertEngine) checkProcessAlert(serverID uint, config ThresholdConfig) (
 	if err != nil {
 		return false, ""
 	}
-	
+
 	if a.compareValue(float64(metric.ProcessCount), config.Operator, config.Value) {
 		return true, fmt.Sprintf("进程数 %d %s %.0f", metric.ProcessCount, a.operatorText(config.Operator), config.Value)
 	}
-	
+
 	return false, ""
 }
 
@@ -256,11 +266,11 @@ func (a *AlertEngine) checkOfflineAlert(serverID uint) (bool, string) {
 	if err != nil {
 		return false, ""
 	}
-	
+
 	if !online {
 		return true, "服务器离线"
 	}
-	
+
 	return false, ""
 }
 
@@ -300,31 +310,44 @@ func (a *AlertEngine) operatorText(operator string) string {
 	}
 }
 
-// handleAlertState 处理告警状态
-func (a *AlertEngine) handleAlertState(alert model.MonitorAlert, serverID uint, triggered bool, content string) {
-	stateKey := fmt.Sprintf("%d:%d", alert.ID, serverID)
-	
+// alertTarget 告警对象
+// kind=server：阈值/离线告警，targetID 为被监控的服务器 ID
+// kind=probe：探测失败告警，targetID 为执行探测的服务器 ID，probeID 为探测配置 ID
+type alertTarget struct {
+	kind     string
+	targetID uint
+	probeID  uint
+}
+
+// handleAlertState 处理告警状态（去重、静默限流、恢复）
+// event: "trigger" 达到触发条件 / "recover" 达到恢复条件 / "" 依据不足，维持现状
+func (a *AlertEngine) handleAlertState(alert model.MonitorAlert, obj alertTarget, event string, content string) {
+	stateKey := fmt.Sprintf("%d:%s:%d", alert.ID, obj.kind, obj.targetID)
+	if obj.kind == "probe" {
+		stateKey = fmt.Sprintf("%d:probe:%d:%d", alert.ID, obj.probeID, obj.targetID)
+	}
+
 	stateVal, _ := a.alertStates.LoadOrStore(stateKey, &AlertState{
 		AlertID:  alert.ID,
-		ServerID: serverID,
+		ServerID: obj.targetID,
 	})
 	state := stateVal.(*AlertState)
-	
+
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	
+
 	now := time.Now()
-	
-	if triggered {
+
+	switch event {
+	case "trigger":
 		state.TriggerCount++
 		state.LastTriggerTime = now
-		
-		// 检查是否需要发送告警
+
 		if !state.IsTriggered {
 			// 首次触发，创建告警记录
 			record := &model.MonitorAlertRecord{
 				AlertID:      alert.ID,
-				ServerID:     serverID,
+				ServerID:     obj.targetID,
 				TriggerTime:  now,
 				Severity:     alert.Severity,
 				AlertContent: content,
@@ -332,32 +355,29 @@ func (a *AlertEngine) handleAlertState(alert model.MonitorAlert, serverID uint, 
 			a.db.Create(record)
 			state.RecordID = record.ID
 			state.IsTriggered = true
-			
+
 			// 发送通知
-			a.sendNotification(alert, serverID, content)
+			a.sendNotification(alert, obj.targetID, content)
 			state.LastNotifyTime = now
-			
-			log.Printf("[AlertEngine] 触发告警: %s, 服务器: %d, 内容: %s\n", alert.Name, serverID, content)
-		} else {
-			// 已触发，检查是否需要重复通知
-			if now.Sub(state.LastNotifyTime).Seconds() >= float64(alert.RateLimit) {
-				a.sendNotification(alert, serverID, content)
-				state.LastNotifyTime = now
-			}
+
+			log.Printf("[AlertEngine] 触发告警: %s, 对象: %s:%d, 内容: %s\n", alert.Name, obj.kind, obj.targetID, content)
+		} else if now.Sub(state.LastNotifyTime).Seconds() >= float64(alert.RateLimit) {
+			// 已触发，静默期后重复通知
+			a.sendNotification(alert, obj.targetID, content)
+			state.LastNotifyTime = now
 		}
-	} else {
-		// 未触发
+	case "recover":
 		if state.IsTriggered {
 			// 告警恢复
 			recoverTime := now
 			a.db.Model(&model.MonitorAlertRecord{}).
 				Where("id = ?", state.RecordID).
 				Update("recover_time", recoverTime)
-			
+
 			state.IsTriggered = false
 			state.TriggerCount = 0
-			
-			log.Printf("[AlertEngine] 告警恢复: %s, 服务器: %d\n", alert.Name, serverID)
+
+			log.Printf("[AlertEngine] 告警恢复: %s, 对象: %s:%d\n", alert.Name, obj.kind, obj.targetID)
 		}
 	}
 }
@@ -370,17 +390,17 @@ func (a *AlertEngine) sendNotification(alert model.MonitorAlert, serverID uint, 
 		log.Printf("[AlertEngine] 解析通知渠道失败: %v\n", err)
 		return
 	}
-	
+
 	// 获取服务器信息
 	var server model.MonitorServer
 	if err := a.db.First(&server, serverID).Error; err != nil {
 		return
 	}
-	
+
 	// 构造通知内容
 	message := fmt.Sprintf("[%s] %s\n服务器: %s\n告警内容: %s\n时间: %s",
 		alert.Severity, alert.Name, server.Name, content, time.Now().Format("2006-01-02 15:04:05"))
-	
+
 	// 发送通知
 	for _, channelID := range channelIDs {
 		go a.manager.Notification.Send(channelID, alert.Name, message)
@@ -391,20 +411,131 @@ func (a *AlertEngine) sendNotification(alert model.MonitorAlert, serverID uint, 
 func (a *AlertEngine) TriggerOfflineAlert(serverID uint) {
 	var alerts []model.MonitorAlert
 	a.db.Where("enable = ? AND alert_type = ?", true, "offline").Find(&alerts)
-	
+
 	for _, alert := range alerts {
 		a.checkServerAlert(alert, serverID)
 	}
 }
 
+// TriggerProbeAlert 探测引擎在连续失败达阈值时主动调用，无需等待检查周期
+func (a *AlertEngine) TriggerProbeAlert(probe model.MonitorProbe, serverID uint) {
+	var alerts []model.MonitorAlert
+	a.db.Where("enable = ? AND alert_type = ?", true, "probe").Find(&alerts)
+
+	for _, alert := range alerts {
+		matched := false
+		for _, id := range a.resolveProbeTargets(alert.TargetServers) {
+			if id == probe.ID {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		if state, content := a.probeState(probe, serverID); state == "trigger" {
+			a.handleAlertState(alert, alertTarget{kind: "probe", targetID: serverID, probeID: probe.ID}, state, content)
+		}
+	}
+}
+
+// checkProbeAlert 检查探测失败告警规则，覆盖规则目标中的每个（探测×执行服务器）组合
+func (a *AlertEngine) checkProbeAlert(alert model.MonitorAlert) {
+	for _, probeID := range a.resolveProbeTargets(alert.TargetServers) {
+		var probe model.MonitorProbe
+		if err := a.db.First(&probe, probeID).Error; err != nil {
+			log.Printf("[AlertEngine] 探测配置不存在: %d\n", probeID)
+			continue
+		}
+		var serverIDs []uint
+		if err := json.Unmarshal([]byte(probe.ServerIDs), &serverIDs); err != nil {
+			log.Printf("[AlertEngine] 解析探测执行服务器失败: probe=%d err=%v\n", probeID, err)
+			continue
+		}
+		for _, serverID := range serverIDs {
+			state, content := a.probeState(probe, serverID)
+			a.handleAlertState(alert, alertTarget{kind: "probe", targetID: serverID, probeID: probeID}, state, content)
+		}
+	}
+}
+
+// resolveProbeTargets 解析 "probe:N" 形式的探测目标
+func (a *AlertEngine) resolveProbeTargets(targets string) []uint {
+	var raw []string
+	if err := json.Unmarshal([]byte(targets), &raw); err != nil {
+		log.Printf("[AlertEngine] 解析探测目标失败: %v\n", err)
+		return nil
+	}
+
+	var probeIDs []uint
+	for _, t := range raw {
+		var id uint
+		if _, err := fmt.Sscanf(t, "probe:%d", &id); err == nil {
+			probeIDs = append(probeIDs, id)
+		}
+	}
+	return probeIDs
+}
+
+// probeState 评估（探测×执行服务器）当前状态
+// 返回 "trigger"（连续失败达 FailThreshold）、"recover"（连续成功达 RecoverThreshold）或 ""（依据不足，维持现状）
+func (a *AlertEngine) probeState(probe model.MonitorProbe, serverID uint) (string, string) {
+	limit := probe.FailThreshold
+	if probe.RecoverThreshold > limit {
+		limit = probe.RecoverThreshold
+	}
+	if limit <= 0 {
+		return "", ""
+	}
+
+	var recent []model.MonitorProbeResult
+	a.db.Where("probe_id = ? AND server_id = ?", probe.ID, serverID).
+		Order("timestamp DESC").Limit(limit).Find(&recent)
+
+	// 最近 FailThreshold 次全部失败 → 触发
+	if probe.FailThreshold > 0 && len(recent) >= probe.FailThreshold {
+		allFailed := true
+		for _, r := range recent[:probe.FailThreshold] {
+			if r.Success {
+				allFailed = false
+				break
+			}
+		}
+		if allFailed {
+			return "trigger", fmt.Sprintf("探测 %s（%s %s:%d）连续失败 %d 次",
+				probe.Name, probe.ProbeType, probe.TargetAddr, probe.TargetPort, probe.FailThreshold)
+		}
+	}
+
+	// 最近 RecoverThreshold 次全部成功 → 恢复
+	recoverN := probe.RecoverThreshold
+	if recoverN <= 0 {
+		recoverN = 1
+	}
+	if len(recent) >= recoverN {
+		allSuccess := true
+		for _, r := range recent[:recoverN] {
+			if !r.Success {
+				allSuccess = false
+				break
+			}
+		}
+		if allSuccess {
+			return "recover", ""
+		}
+	}
+
+	return "", ""
+}
+
 // ListAlerts 列出告警规则
 func (a *AlertEngine) ListAlerts(enable *bool) ([]model.MonitorAlert, error) {
 	query := a.db.Model(&model.MonitorAlert{})
-	
+
 	if enable != nil {
 		query = query.Where("enable = ?", *enable)
 	}
-	
+
 	var alerts []model.MonitorAlert
 	err := query.Order("id ASC").Find(&alerts).Error
 	return alerts, err
@@ -427,10 +558,10 @@ func (a *AlertEngine) DeleteAlert(id uint) error {
 		if err := tx.Delete(&model.MonitorAlert{}, id).Error; err != nil {
 			return err
 		}
-		
+
 		// 删除告警记录
 		tx.Where("alert_id = ?", id).Delete(&model.MonitorAlertRecord{})
-		
+
 		return nil
 	})
 }
@@ -438,23 +569,23 @@ func (a *AlertEngine) DeleteAlert(id uint) error {
 // GetAlertRecords 获取告警记录
 func (a *AlertEngine) GetAlertRecords(alertID, serverID uint, start, end time.Time, limit int) ([]model.MonitorAlertRecord, error) {
 	query := a.db.Model(&model.MonitorAlertRecord{})
-	
+
 	if alertID > 0 {
 		query = query.Where("alert_id = ?", alertID)
 	}
-	
+
 	if serverID > 0 {
 		query = query.Where("server_id = ?", serverID)
 	}
-	
+
 	if !start.IsZero() && !end.IsZero() {
 		query = query.Where("trigger_time BETWEEN ? AND ?", start, end)
 	}
-	
+
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
-	
+
 	var records []model.MonitorAlertRecord
 	err := query.Order("trigger_time DESC").Find(&records).Error
 	return records, err

--- a/backend/service/monitor/alert_test.go
+++ b/backend/service/monitor/alert_test.go
@@ -1,0 +1,198 @@
+package monitor
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/netpanel/netpanel/model"
+)
+
+func newAlertTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "alert_test.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("打开测试数据库失败: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&model.MonitorProbe{},
+		&model.MonitorProbeResult{},
+		&model.MonitorAlert{},
+		&model.MonitorAlertRecord{},
+		&model.MonitorServer{},
+	); err != nil {
+		t.Fatalf("迁移测试表失败: %v", err)
+	}
+	return db
+}
+
+// seedProbe 写入探测配置与按时间升序的探测结果（最新的最后写入）
+func seedProbe(t *testing.T, db *gorm.DB, successes ...bool) model.MonitorProbe {
+	t.Helper()
+	probe := model.MonitorProbe{
+		Name:             "测试探测",
+		Enable:           true,
+		ProbeType:        "tcp",
+		TargetAddr:       "192.0.2.10",
+		TargetPort:       8080,
+		Interval:         60,
+		ServerIDs:        `["1"]`,
+		FailThreshold:    3,
+		RecoverThreshold: 2,
+	}
+	if err := db.Create(&probe).Error; err != nil {
+		t.Fatalf("创建探测配置失败: %v", err)
+	}
+	base := time.Now().Add(-time.Duration(len(successes)+1) * time.Minute)
+	for i, s := range successes {
+		r := model.MonitorProbeResult{
+			ProbeID:   probe.ID,
+			ServerID:  1,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Success:   s,
+		}
+		if err := db.Create(&r).Error; err != nil {
+			t.Fatalf("写入探测结果失败: %v", err)
+		}
+	}
+	return probe
+}
+
+func TestResolveProbeTargets(t *testing.T) {
+	a := &AlertEngine{}
+	got := a.resolveProbeTargets(`["probe:1","probe:22","server:3","group:default"]`)
+	if len(got) != 2 || got[0] != 1 || got[1] != 22 {
+		t.Fatalf("期望解析出 [1 22]，实际 %v", got)
+	}
+	if got := a.resolveProbeTargets(`不是 JSON`); got != nil {
+		t.Fatalf("非法 JSON 应返回 nil，实际 %v", got)
+	}
+}
+
+func TestProbeState_ThreeStates(t *testing.T) {
+	db := newAlertTestDB(t)
+	a := NewAlertEngine(db, nil)
+
+	// 结果不足 FailThreshold → 依据不足
+	probe := seedProbe(t, db, false, false)
+	if state, _ := a.probeState(probe, 1); state != "" {
+		t.Fatalf("结果不足时应为空状态，实际 %q", state)
+	}
+
+	// 连续失败达 FailThreshold → trigger
+	db.Create(&model.MonitorProbeResult{ProbeID: probe.ID, ServerID: 1, Timestamp: time.Now(), Success: false})
+	if state, content := a.probeState(probe, 1); state != "trigger" || content == "" {
+		t.Fatalf("连续失败 3 次应触发，实际 %q %q", state, content)
+	}
+
+	// 失败后仅 1 次成功 → 依据不足（未达恢复阈值）
+	db.Create(&model.MonitorProbeResult{ProbeID: probe.ID, ServerID: 1, Timestamp: time.Now(), Success: true})
+	if state, _ := a.probeState(probe, 1); state != "" {
+		t.Fatalf("1 次成功未达恢复阈值应为空状态，实际 %q", state)
+	}
+
+	// 连续成功达 RecoverThreshold → recover
+	db.Create(&model.MonitorProbeResult{ProbeID: probe.ID, ServerID: 1, Timestamp: time.Now(), Success: true})
+	if state, _ := a.probeState(probe, 1); state != "recover" {
+		t.Fatalf("连续成功 2 次应恢复，实际 %q", state)
+	}
+}
+
+func TestHandleAlertState_ProbeLifecycle(t *testing.T) {
+	db := newAlertTestDB(t)
+	a := NewAlertEngine(db, nil)
+
+	probe := seedProbe(t, db, false, false, false)
+	alert := model.MonitorAlert{
+		Name:            "探测失败告警",
+		Enable:          true,
+		AlertType:       "probe",
+		TargetServers:   `["probe:1"]`,
+		NotifyChannels:  `[]`,
+		Severity:        "warning",
+		SilenceDuration: 3600,
+		RateLimit:       300,
+	}
+	if err := db.Create(&alert).Error; err != nil {
+		t.Fatalf("创建告警规则失败: %v", err)
+	}
+
+	obj := alertTarget{kind: "probe", targetID: 1, probeID: probe.ID}
+
+	// 首次触发：创建告警记录
+	a.handleAlertState(alert, obj, "trigger", "探测失败")
+	var records []model.MonitorAlertRecord
+	db.Where("alert_id = ?", alert.ID).Find(&records)
+	if len(records) != 1 || records[0].RecoverTime != nil {
+		t.Fatalf("首次触发应有 1 条未恢复记录，实际 %d 条", len(records))
+	}
+
+	// 持续失败（静默期内）：不重复建记录
+	a.handleAlertState(alert, obj, "trigger", "探测失败")
+	db.Where("alert_id = ?", alert.ID).Find(&records)
+	if len(records) != 1 {
+		t.Fatalf("静默期内重复触发不应新建记录，实际 %d 条", len(records))
+	}
+
+	// 恢复：补齐恢复时间，状态复位
+	a.handleAlertState(alert, obj, "recover", "")
+	db.Where("alert_id = ?", alert.ID).Find(&records)
+	if len(records) != 1 || records[0].RecoverTime == nil {
+		t.Fatalf("恢复后记录应带恢复时间")
+	}
+
+	// 恢复后再次失败：新建一条记录
+	a.handleAlertState(alert, obj, "trigger", "探测失败")
+	db.Where("alert_id = ?", alert.ID).Find(&records)
+	if len(records) != 2 {
+		t.Fatalf("恢复后再次触发应新建记录，实际 %d 条", len(records))
+	}
+}
+
+func TestTriggerProbeAlert_RespectsRuleTargets(t *testing.T) {
+	db := newAlertTestDB(t)
+	a := NewAlertEngine(db, nil)
+
+	probe := seedProbe(t, db, false, false, false)
+	// 规则目标不含该探测 → 不应产生告警记录
+	other := model.MonitorAlert{
+		Name:           "其他探测的告警",
+		Enable:         true,
+		AlertType:      "probe",
+		TargetServers:  `["probe:999"]`,
+		NotifyChannels: `[]`,
+		Severity:       "warning",
+	}
+	if err := db.Create(&other).Error; err != nil {
+		t.Fatalf("创建告警规则失败: %v", err)
+	}
+
+	a.TriggerProbeAlert(probe, 1)
+	var count int64
+	db.Model(&model.MonitorAlertRecord{}).Count(&count)
+	if count != 0 {
+		t.Fatalf("目标不匹配时不应产生告警记录，实际 %d 条", count)
+	}
+
+	// 目标匹配 → 产生记录
+	matched := model.MonitorAlert{
+		Name:           "匹配的探测告警",
+		Enable:         true,
+		AlertType:      "probe",
+		TargetServers:  `["probe:` + strconv.FormatUint(uint64(probe.ID), 10) + `"]`,
+		NotifyChannels: `[]`,
+		Severity:       "warning",
+	}
+	if err := db.Create(&matched).Error; err != nil {
+		t.Fatalf("创建告警规则失败: %v", err)
+	}
+	a.TriggerProbeAlert(probe, 1)
+	db.Model(&model.MonitorAlertRecord{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("目标匹配时应产生 1 条告警记录，实际 %d 条", count)
+	}
+}

--- a/backend/service/monitor/collector.go
+++ b/backend/service/monitor/collector.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -320,7 +321,7 @@ func (c *Collector) ProbeHTTP(probeURL string, timeout int) (bool, int64, int, e
 
 // ProbeTCP TCP 探测
 func (c *Collector) ProbeTCP(addr string, port int, timeout int) (bool, int64, error) {
-	target := fmt.Sprintf("%s:%d", addr, port)
+	target := net.JoinHostPort(addr, strconv.Itoa(port))
 	
 	start := time.Now()
 	conn, err := net.DialTimeout("tcp", target, time.Duration(timeout)*time.Second)
@@ -336,7 +337,7 @@ func (c *Collector) ProbeTCP(addr string, port int, timeout int) (bool, int64, e
 
 // ProbeUDP UDP 探测
 func (c *Collector) ProbeUDP(addr string, port int, timeout int) (bool, int64, error) {
-	target := fmt.Sprintf("%s:%d", addr, port)
+	target := net.JoinHostPort(addr, strconv.Itoa(port))
 	
 	start := time.Now()
 	conn, err := net.DialTimeout("udp", target, time.Duration(timeout)*time.Second)

--- a/backend/service/monitor/probe.go
+++ b/backend/service/monitor/probe.go
@@ -16,11 +16,11 @@ import (
 type ProbeEngine struct {
 	db      *gorm.DB
 	manager *Manager
-	
+
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
-	
+
 	// 探测任务
 	probeTickers map[uint]*time.Ticker
 	mu           sync.RWMutex
@@ -29,7 +29,7 @@ type ProbeEngine struct {
 // NewProbeEngine 创建探测引擎
 func NewProbeEngine(db *gorm.DB, manager *Manager) *ProbeEngine {
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	return &ProbeEngine{
 		db:           db,
 		manager:      manager,
@@ -42,24 +42,24 @@ func NewProbeEngine(db *gorm.DB, manager *Manager) *ProbeEngine {
 // Start 启动探测引擎
 func (p *ProbeEngine) Start() {
 	log.Println("[ProbeEngine] 启动探测引擎...")
-	
+
 	// 加载所有启用的探测配置
 	var probes []model.MonitorProbe
 	p.db.Where("enable = ?", true).Find(&probes)
-	
+
 	for _, probe := range probes {
 		p.StartProbe(probe)
 	}
-	
+
 	log.Printf("[ProbeEngine] 探测引擎启动完成，加载了 %d 个探测任务\n", len(probes))
 }
 
 // Stop 停止探测引擎
 func (p *ProbeEngine) Stop() {
 	log.Println("[ProbeEngine] 停止探测引擎...")
-	
+
 	p.cancel()
-	
+
 	// 停止所有探测任务
 	p.mu.Lock()
 	for _, ticker := range p.probeTickers {
@@ -67,7 +67,7 @@ func (p *ProbeEngine) Stop() {
 	}
 	p.probeTickers = make(map[uint]*time.Ticker)
 	p.mu.Unlock()
-	
+
 	p.wg.Wait()
 	log.Println("[ProbeEngine] 探测引擎已停止")
 }
@@ -76,24 +76,24 @@ func (p *ProbeEngine) Stop() {
 func (p *ProbeEngine) StartProbe(probe model.MonitorProbe) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	
+
 	// 如果已存在，先停止
 	if ticker, ok := p.probeTickers[probe.ID]; ok {
 		ticker.Stop()
 	}
-	
+
 	// 创建定时器
 	ticker := time.NewTicker(time.Duration(probe.Interval) * time.Second)
 	p.probeTickers[probe.ID] = ticker
-	
+
 	// 启动探测协程
 	p.wg.Add(1)
 	go func(probe model.MonitorProbe) {
 		defer p.wg.Done()
-		
+
 		// 立即执行一次
 		p.executeProbe(probe)
-		
+
 		for {
 			select {
 			case <-p.ctx.Done():
@@ -103,7 +103,7 @@ func (p *ProbeEngine) StartProbe(probe model.MonitorProbe) {
 			}
 		}
 	}(probe)
-	
+
 	log.Printf("[ProbeEngine] 启动探测任务: %s (间隔 %d 秒)\n", probe.Name, probe.Interval)
 }
 
@@ -111,7 +111,7 @@ func (p *ProbeEngine) StartProbe(probe model.MonitorProbe) {
 func (p *ProbeEngine) StopProbe(probeID uint) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	
+
 	if ticker, ok := p.probeTickers[probeID]; ok {
 		ticker.Stop()
 		delete(p.probeTickers, probeID)
@@ -127,7 +127,7 @@ func (p *ProbeEngine) executeProbe(probe model.MonitorProbe) {
 		log.Printf("[ProbeEngine] 解析服务器列表失败: %v\n", err)
 		return
 	}
-	
+
 	// 在每个服务器上执行探测
 	for _, serverID := range serverIDs {
 		go p.probeOnServer(probe, serverID)
@@ -141,12 +141,12 @@ func (p *ProbeEngine) probeOnServer(probe model.MonitorProbe, serverID uint) {
 		ServerID:  serverID,
 		Timestamp: time.Now(),
 	}
-	
+
 	var success bool
 	var responseTime int64
 	var statusCode int
 	var err error
-	
+
 	// 根据探测类型执行
 	switch probe.ProbeType {
 	case "tcp":
@@ -170,20 +170,20 @@ func (p *ProbeEngine) probeOnServer(probe model.MonitorProbe, serverID uint) {
 		log.Printf("[ProbeEngine] 不支持的探测类型: %s\n", probe.ProbeType)
 		return
 	}
-	
+
 	result.Success = success
 	result.ResponseTime = responseTime
 	result.StatusCode = statusCode
-	
+
 	if err != nil {
 		result.ErrorMsg = err.Error()
 	}
-	
+
 	// 保存探测结果
 	if err := p.db.Create(result).Error; err != nil {
 		log.Printf("[ProbeEngine] 保存探测结果失败: %v\n", err)
 	}
-	
+
 	// 检查是否需要触发告警
 	p.checkProbeAlert(probe, serverID, success)
 }
@@ -196,11 +196,11 @@ func (p *ProbeEngine) checkProbeAlert(probe model.MonitorProbe, serverID uint, s
 		Order("timestamp DESC").
 		Limit(probe.FailThreshold).
 		Find(&recentResults)
-	
+
 	if len(recentResults) < probe.FailThreshold {
 		return
 	}
-	
+
 	// 检查是否连续失败
 	allFailed := true
 	for _, r := range recentResults {
@@ -209,22 +209,24 @@ func (p *ProbeEngine) checkProbeAlert(probe model.MonitorProbe, serverID uint, s
 			break
 		}
 	}
-	
+
 	if allFailed {
-		// 触发告警
+		// 触发告警：立即通知告警引擎（其内部做去重与静默限流），恢复由检查周期统一判定
 		log.Printf("[ProbeEngine] 探测 %s 连续失败 %d 次，触发告警\n", probe.Name, probe.FailThreshold)
-		// TODO: 调用告警引擎
+		if p.manager != nil && p.manager.AlertEngine != nil {
+			p.manager.AlertEngine.TriggerProbeAlert(probe, serverID)
+		}
 	}
 }
 
 // ListProbes 列出探测配置
 func (p *ProbeEngine) ListProbes(enable *bool) ([]model.MonitorProbe, error) {
 	query := p.db.Model(&model.MonitorProbe{})
-	
+
 	if enable != nil {
 		query = query.Where("enable = ?", *enable)
 	}
-	
+
 	var probes []model.MonitorProbe
 	err := query.Order("id ASC").Find(&probes).Error
 	return probes, err
@@ -235,11 +237,11 @@ func (p *ProbeEngine) CreateProbe(probe *model.MonitorProbe) error {
 	if err := p.db.Create(probe).Error; err != nil {
 		return err
 	}
-	
+
 	if probe.Enable {
 		p.StartProbe(*probe)
 	}
-	
+
 	return nil
 }
 
@@ -248,13 +250,13 @@ func (p *ProbeEngine) UpdateProbe(probe *model.MonitorProbe) error {
 	if err := p.db.Save(probe).Error; err != nil {
 		return err
 	}
-	
+
 	// 重启探测任务
 	p.StopProbe(probe.ID)
 	if probe.Enable {
 		p.StartProbe(*probe)
 	}
-	
+
 	return nil
 }
 
@@ -262,16 +264,16 @@ func (p *ProbeEngine) UpdateProbe(probe *model.MonitorProbe) error {
 func (p *ProbeEngine) DeleteProbe(id uint) error {
 	// 停止探测任务
 	p.StopProbe(id)
-	
+
 	return p.db.Transaction(func(tx *gorm.DB) error {
 		// 删除探测配置
 		if err := tx.Delete(&model.MonitorProbe{}, id).Error; err != nil {
 			return err
 		}
-		
+
 		// 删除探测结果
 		tx.Where("probe_id = ?", id).Delete(&model.MonitorProbeResult{})
-		
+
 		return nil
 	})
 }
@@ -279,15 +281,15 @@ func (p *ProbeEngine) DeleteProbe(id uint) error {
 // GetProbeResults 获取探测结果
 func (p *ProbeEngine) GetProbeResults(probeID, serverID uint, start, end time.Time) ([]model.MonitorProbeResult, error) {
 	query := p.db.Where("probe_id = ?", probeID)
-	
+
 	if serverID > 0 {
 		query = query.Where("server_id = ?", serverID)
 	}
-	
+
 	if !start.IsZero() && !end.IsZero() {
 		query = query.Where("timestamp BETWEEN ? AND ?", start, end)
 	}
-	
+
 	var results []model.MonitorProbeResult
 	err := query.Order("timestamp ASC").Find(&results).Error
 	return results, err

--- a/backend/service/portforward/manager.go
+++ b/backend/service/portforward/manager.go
@@ -3,6 +3,7 @@ package portforward
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -124,7 +125,7 @@ func (p *TCPProxy) handleConn(src net.Conn) {
 		src.Close()
 	}()
 
-	dst, err := net.Dial("tcp", fmt.Sprintf("%s:%d", p.targetAddr, p.targetPort))
+	dst, err := net.Dial("tcp", net.JoinHostPort(p.targetAddr, strconv.Itoa(p.targetPort)))
 	if err != nil {
 		p.log.Errorf("连接目标[TCP] %s:%d 失败: %v", p.targetAddr, p.targetPort, err)
 		return

--- a/backend/service/portforward/socks5_proxy.go
+++ b/backend/service/portforward/socks5_proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -185,7 +186,7 @@ func (p *SOCKS5Proxy) handleConn(conn net.Conn) {
 		return
 	}
 	targetPort := binary.BigEndian.Uint16(portBuf)
-	fullTarget := fmt.Sprintf("%s:%d", targetAddr, targetPort)
+	fullTarget := net.JoinHostPort(targetAddr, strconv.Itoa(int(targetPort)))
 
 	// 目前只支持 CONNECT（TCP 代理）
 	if cmd != 0x01 {

--- a/webpage/src/pages/MonitorAlerts.tsx
+++ b/webpage/src/pages/MonitorAlerts.tsx
@@ -67,6 +67,7 @@ const MonitorAlerts: React.FC = () => {
   const [editingAlert, setEditingAlert] = useState<Alert | null>(null)
   const [activeTab, setActiveTab] = useState('rules')
   const [form] = Form.useForm()
+  const alertType = Form.useWatch('alert_type', form)
 
   useEffect(() => {
     loadAlerts()
@@ -373,7 +374,9 @@ const MonitorAlerts: React.FC = () => {
           <Form.Item name="target_servers" label={t('monitor.target_servers')} rules={[{ required: true }]}>
             <TextArea
               rows={2}
-              placeholder='目标服务器，JSON 格式，例如: ["server:1","server:2"] 或 ["group:default"]'
+              placeholder={alertType === 'probe'
+                ? '目标探测，JSON 格式，例如: ["probe:1"]'
+                : '目标服务器，JSON 格式，例如: ["server:1","server:2"] 或 ["group:default"]'}
             />
           </Form.Item>
 


### PR DESCRIPTION
## 中文

`MonitorAlert.AlertType` 的注释与前端「告警规则」表单很早就预留了 **probe（探测失败）** 类型，`ProbeEngine.checkProbeAlert` 也已实现连续失败检测，但 `alert.go` 的规则求值 switch 从未实现 probe 分支，`probe.go` 达到失败阈值后只有一行 TODO——结果是：探测发现了服务不可达，但永远不会产生告警记录或发出通知。

本 PR 把这条断链接通（复用 AlertEngine 既有的去重 / 静默 / 限流 / 恢复机制）：

### 后端
- `alert.go`
  - `checkAlert` 增加 `alert_type=probe` 分支：规则目标支持 `["probe:N"]`（新增 `resolveProbeTargets`），对规则覆盖的每个（探测 × 执行服务器）组合求值
  - 新增 `probeState` 三态判定：最近 `FailThreshold` 次全失败 → trigger；最近 `RecoverThreshold` 次全成功 → recover；依据不足 → 维持现状
  - `handleAlertState` 重构为通用告警对象（`alertTarget`：server / probe），probe 告警的状态键含 probeID，避免同服务器多探测互相覆盖；告警记录的 `ServerID` 存执行探测的服务器，语义与既有记录一致
  - 新增 `TriggerProbeAlert`：探测引擎达阈值时主动调用，不必等 30s 检查周期；两个入口共用同一状态机，不会重复通知
- `probe.go`：`checkProbeAlert` 的 TODO 替换为调用 `TriggerProbeAlert`

### 前端
- `MonitorAlerts.tsx`：告警类型为「探测失败」时，目标输入框提示 `["probe:N"]` 格式（原先只提示 server/group，probe 规则无从下手）

### 验证
- 新增 `alert_test.go`（内存 sqlite）：目标解析、三态判定、触发→静默→恢复→再触发全生命周期、规则目标不匹配不误报
- `go build` / `go vet`（0 告警）/ `go test ./service/monitor/` 通过；前端 `tsc && vite build` 通过
- `service/linereg` 有 3 个测试在上游 main 上即失败（TestBuildLines 等，缺 cftunnel 线路），与本 PR 无关，未改动

---

## English

The schema, UI and `ProbeEngine` all anticipated a **probe** alert type, but `AlertEngine` never implemented it and `probe.go` stopped at a TODO — probes detected outages yet never created alert records or sent notifications. This wires the missing link, reusing the engine's existing dedup / silence / rate-limit / recovery state machine: `resolveProbeTargets` + `probeState` (three-state via Fail/RecoverThreshold) + a generalized `handleAlertState` (per probe×server state keys) + `TriggerProbeAlert` for immediate notification from the probe loop. Frontend target placeholder now hints the `["probe:N"]` syntax for probe rules. Covered by new sqlite-backed unit tests.