### PR TITLE
fix(cftunnel): 收尾 #40 模型迁移 — 修复创建后无法启动，删除旧模型 / Finish #40 model migration: fix start-after-create, drop legacy model

### DIFF
--- a/backend/model/db.go
+++ b/backend/model/db.go
@@ -94,7 +94,7 @@ func autoMigrate(db *gorm.DB) error {
 		&OAuthProviderConfig{},
 		&IPDBSubscription{},
 		&WireguardConfig{},
-		&WireguardPeer{}, WireguardPeer{},
+		&WireguardPeer{},
 		&MeshNode{},
 		&MeshNodeEvent{},
 		// AI 管理模块

--- a/backend/model/db.go
+++ b/backend/model/db.go
@@ -65,7 +65,6 @@ func autoMigrate(db *gorm.DB) error {
 		&NpsClientConfig{},
 		&EasytierClient{},
 		&EasytierServer{},
-		&CftunnelConfig{},
 		&TunService{},
 		&ProbeHistory{},
 		&NpsTunnel{},

--- a/backend/model/models.go
+++ b/backend/model/models.go
@@ -549,35 +549,6 @@ type EasytierServer struct {
 	Remark    string `gorm:"size:500" json:"remark"`
 }
 
-// ===== Cloudflare Tunnel (cloudflared) =====
-
-// CftunnelConfig Cloudflare Tunnel 配置
-type CftunnelConfig struct {
-	BaseModel
-	Name   string `gorm:"size:100;not null" json:"name"`
-	Enable bool   `gorm:"default:false" json:"enable"`
-	// 模式：quick（临时隧道）/ named（命名隧道）/ token（远程配置）
-	Mode string `gorm:"size:20;default:'quick'" json:"mode"`
-	// 本地服务地址，如 http://127.0.0.1:8080
-	LocalURL string `gorm:"size:500" json:"local_url"`
-	// named 模式：隧道名称或 UUID
-	TunnelName string `gorm:"size:255" json:"tunnel_name"`
-	// named 模式：凭据文件路径（可选，默认 ~/.cloudflared/<uuid>.json）
-	CredentialsFile string `gorm:"size:500" json:"credentials_file"`
-	// named 模式：配置文件路径（可选，默认为临时生成的 config.yml）
-	ConfigFile string `gorm:"size:500" json:"config_file"`
-	// token 模式：远程配置 token（cloudflared tunnel run --token）
-	Token string `gorm:"type:text" json:"token"`
-	// 协议：http/https，默认 http
-	Protocol string `gorm:"size:20;default:'http'" json:"protocol"`
-	// QuickURL quick 模式的临时隧道地址（每次启动随机生成，
-	// 从 cloudflared stdout 自动提取，供前端直接展示可访问入口）
-	QuickURL  string `gorm:"size:500" json:"quick_url"`
-	Status    string `gorm:"size:20;default:'stopped'" json:"status"`
-	LastError string `gorm:"type:text" json:"last_error"`
-	Remark    string `gorm:"size:500" json:"remark"`
-}
-
 // ===== 穿透服务（用户视角） =====
 
 // TunService 穿透服务：一个「目标服务」由多条线路（frp/nps/easytier/wg/cf…）提供访问

--- a/backend/service/cftunnel/manager.go
+++ b/backend/service/cftunnel/manager.go
@@ -1,5 +1,5 @@
 // Package cftunnel Cloudflare Tunnel (cloudflared) 进程管理：
-// 支持 quick（临时隧道）/ named（命名隧道）/ token（远程配置）三种模式，
+// 支持 quick（临时隧道）/ named（命名隧道，Token 认证）两种模式，
 // 通过命令行方式管理 cloudflared 进程（与 easytier 类似的进程管理方式）。
 package cftunnel
 
@@ -26,8 +26,6 @@ const (
 	maxLogLines = 500
 	// binaryName cloudflared 可执行文件名
 	binaryName = "cloudflared"
-	// configDirName named 模式临时配置目录
-	configDirName = "cftunnel"
 )
 
 // quickURLRe 匹配 cloudflared quick 模式日志中的临时隧道地址，
@@ -116,7 +114,7 @@ func (m *Manager) GetBinDir() string {
 
 // StartAll 启动所有启用状态的隧道
 func (m *Manager) StartAll() {
-	var tunnels []model.CftunnelConfig
+	var tunnels []model.CloudflareTunnel
 	if err := m.db.Where("enable = ?", true).Find(&tunnels).Error; err != nil {
 		m.log.Warnf("[CF隧道] 读取配置失败: %v", err)
 		return
@@ -147,14 +145,14 @@ func (m *Manager) Start(id uint) error {
 		return fmt.Errorf("cloudflared 二进制不存在，请先下载: %s", m.getBinaryPath())
 	}
 
-	var cfg model.CftunnelConfig
+	var cfg model.CloudflareTunnel
 	if err := m.db.First(&cfg, id).Error; err != nil {
 		return fmt.Errorf("CF 隧道配置不存在: %w", err)
 	}
 
 	args, err := m.buildArgs(&cfg)
 	if err != nil {
-		m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
+		m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Updates(map[string]interface{}{
 			"status":     "error",
 			"last_error": err.Error(),
 		})
@@ -173,7 +171,7 @@ func (m *Manager) Start(id uint) error {
 
 	if err := cmd.Start(); err != nil {
 		cancel()
-		m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
+		m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Updates(map[string]interface{}{
 			"status":     "error",
 			"last_error": err.Error(),
 		})
@@ -191,9 +189,9 @@ func (m *Manager) Start(id uint) error {
 			logBuf.write(line)
 			// quick 模式：隧道地址每次启动随机生成，从日志中提取并落库，
 			// 前端可直接展示可访问入口，无需翻日志
-			if cfg.Mode == "quick" {
+			if cfg.Type == "quick" {
 				if url := quickURLRe.FindString(line); url != "" {
-					m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Update("quick_url", url)
+					m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Update("public_url", url)
 					m.log.Infof("[CF隧道][%d] quick 入口已更新: %s", id, url)
 				}
 			}
@@ -217,10 +215,10 @@ func (m *Manager) Start(id uint) error {
 		if err != nil {
 			errMsg := fmt.Sprintf("进程异常退出: %v", err)
 			m.log.Warnf("[CF隧道][%d] %s", id, errMsg)
-			m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
+			m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Updates(map[string]interface{}{
 				"status":     "error",
 				"last_error": errMsg,
-				"quick_url":  "",
+				"public_url": "",
 			})
 			// 自动重启（延迟 5 秒，关闭期间不重启）
 			time.Sleep(5 * time.Second)
@@ -230,7 +228,7 @@ func (m *Manager) Start(id uint) error {
 			if isStopping {
 				return
 			}
-			var cur model.CftunnelConfig
+			var cur model.CloudflareTunnel
 			if m.db.First(&cur, id).Error == nil && cur.Enable {
 				m.log.Infof("[CF隧道][%d] 尝试自动重启...", id)
 				if restartErr := m.Start(id); restartErr != nil {
@@ -238,15 +236,15 @@ func (m *Manager) Start(id uint) error {
 				}
 			}
 		} else {
-			m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
+			m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Updates(map[string]interface{}{
 				"status":    "stopped",
-				"quick_url": "",
+				"public_url": "",
 			})
 			m.log.Infof("[CF隧道][%d] 进程已退出", id)
 		}
 	}()
 
-	m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
+	m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Updates(map[string]interface{}{
 		"status":     "running",
 		"last_error": "",
 	})
@@ -266,9 +264,9 @@ func (m *Manager) Stop(id uint) {
 		m.tunnels.Delete(id)
 	}
 	// 进程停止后 quick 隧道地址随即失效，一并清理
-	m.db.Model(&model.CftunnelConfig{}).Where("id = ?", id).Updates(map[string]interface{}{
+	m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Updates(map[string]interface{}{
 		"status":    "stopped",
-		"quick_url": "",
+		"public_url": "",
 	})
 }
 
@@ -297,10 +295,9 @@ func (m *Manager) GetLogs(id uint) []string {
 // buildArgs 根据模式构建 cloudflared 命令行参数。
 //
 //	quick:  cloudflared tunnel --url <local_url> --no-autoupdate
-//	named:  cloudflared tunnel --config <config.yml> run <name|uuid> --no-autoupdate
-//	token:  cloudflared tunnel run --token <token> --no-autoupdate
-func (m *Manager) buildArgs(cfg *model.CftunnelConfig) ([]string, error) {
-	switch cfg.Mode {
+//	named:  cloudflared tunnel run --token <token> --no-autoupdate
+func (m *Manager) buildArgs(cfg *model.CloudflareTunnel) ([]string, error) {
+	switch cfg.Type {
 	case "quick":
 		if cfg.LocalURL == "" {
 			return nil, fmt.Errorf("quick 模式需要填写本地服务地址（LocalURL）")
@@ -308,48 +305,13 @@ func (m *Manager) buildArgs(cfg *model.CftunnelConfig) ([]string, error) {
 		return []string{"tunnel", "--url", cfg.LocalURL, "--no-autoupdate"}, nil
 
 	case "named":
-		if cfg.TunnelName == "" {
-			return nil, fmt.Errorf("named 模式需要填写隧道名称或 UUID")
-		}
-		args := []string{"tunnel"}
-		configPath := cfg.ConfigFile
-		if configPath == "" {
-			// 自动生成临时 config.yml（若凭据文件已提供）
-			if cfg.CredentialsFile != "" {
-				generated, err := m.writeTempConfig(cfg)
-				if err != nil {
-					return nil, err
-				}
-				configPath = generated
-			}
-		}
-		if configPath != "" {
-			args = append(args, "--config", configPath)
-		}
-		args = append(args, "run", cfg.TunnelName, "--no-autoupdate")
-		return args, nil
-
-	case "token":
+		// 命名隧道统一走 Token 认证（与 API 层 Create/Update 校验一致）
 		if cfg.Token == "" {
-			return nil, fmt.Errorf("token 模式需要填写 Token")
+			return nil, fmt.Errorf("named 模式需要填写 Cloudflare Tunnel Token")
 		}
 		return []string{"tunnel", "run", "--token", cfg.Token, "--no-autoupdate"}, nil
 
 	default:
-		return nil, fmt.Errorf("未知模式: %q（可选 quick/named/token）", cfg.Mode)
+		return nil, fmt.Errorf("未知模式: %q（可选 quick/named）", cfg.Type)
 	}
-}
-
-// writeTempConfig 为 named 模式生成临时 config.yml（写入 dataDir/cftunnel/<name>.yml）
-func (m *Manager) writeTempConfig(cfg *model.CftunnelConfig) (string, error) {
-	dir := filepath.Join(m.dataDir, configDirName)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", fmt.Errorf("创建配置目录失败: %w", err)
-	}
-	path := filepath.Join(dir, fmt.Sprintf("tunnel-%d.yml", cfg.ID))
-	content := fmt.Sprintf("tunnel: %s\ncredentials-file: %s\n", cfg.TunnelName, cfg.CredentialsFile)
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		return "", fmt.Errorf("写入配置文件失败: %w", err)
-	}
-	return path, nil
 }

--- a/backend/service/cftunnel/manager.go
+++ b/backend/service/cftunnel/manager.go
@@ -78,10 +78,10 @@ func (r *ringBuffer) lines() []string {
 
 // Manager Cloudflare Tunnel 管理器
 type Manager struct {
-	db      *gorm.DB
-	log     *logrus.Logger
-	dataDir string
-	tunnels sync.Map // map[uint]*processEntry
+	db       *gorm.DB
+	log      *logrus.Logger
+	dataDir  string
+	tunnels  sync.Map // map[uint]*processEntry
 	stopping bool
 	mu       sync.Mutex
 }
@@ -237,7 +237,7 @@ func (m *Manager) Start(id uint) error {
 			}
 		} else {
 			m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Updates(map[string]interface{}{
-				"status":    "stopped",
+				"status":     "stopped",
 				"public_url": "",
 			})
 			m.log.Infof("[CF隧道][%d] 进程已退出", id)
@@ -265,7 +265,7 @@ func (m *Manager) Stop(id uint) {
 	}
 	// 进程停止后 quick 隧道地址随即失效，一并清理
 	m.db.Model(&model.CloudflareTunnel{}).Where("id = ?", id).Updates(map[string]interface{}{
-		"status":    "stopped",
+		"status":     "stopped",
 		"public_url": "",
 	})
 }

--- a/backend/service/linereg/linereg_test.go
+++ b/backend/service/linereg/linereg_test.go
@@ -29,7 +29,7 @@ func newTestDB(t *testing.T) *gorm.DB {
 		&model.EasytierClient{},
 		&model.WireguardConfig{},
 		&model.WireguardPeer{},
-		&model.CftunnelConfig{},
+		&model.CloudflareTunnel{},
 		&model.ProbeHistory{},
 		&model.TunService{},
 	); err != nil {
@@ -60,12 +60,12 @@ func seedData(db *gorm.DB) {
 	db.Model(&peerB).Update("enable", false)
 	db.Create(&model.WireguardPeer{WireguardID: wg.ID, Name: "无端点", Enable: true, PublicKey: "CCC", Endpoint: ""})
 
-	// CF 隧道：仅 named 模式注册为线路
-	db.Create(&model.CftunnelConfig{Name: "cf named", Enable: true, Mode: "named", TunnelName: "my-tunnel", LocalURL: "http://127.0.0.1:8080"})
-	db.Create(&model.CftunnelConfig{Name: "cf quick", Enable: true, Mode: "quick", LocalURL: "http://127.0.0.1:8081"})
-	db.Create(&model.CftunnelConfig{Name: "cf token", Enable: true, Mode: "token", Token: "eyJhIjoi"})
-	db.Create(&model.CftunnelConfig{Name: "cf 停用", Enable: false, Mode: "named", TunnelName: "off-tunnel"})
-	db.Create(&model.CftunnelConfig{Name: "cf 无名", Enable: true, Mode: "named", TunnelName: ""})
+	// CF 隧道：仅 named 模式且有隧道名的注册为线路
+	db.Create(&model.CloudflareTunnel{Name: "cf named", Enable: true, Type: "named", TunnelName: "my-tunnel", LocalURL: "http://127.0.0.1:8080"})
+	db.Create(&model.CloudflareTunnel{Name: "cf quick", Enable: true, Type: "quick", LocalURL: "http://127.0.0.1:8081"})
+	db.Create(&model.CloudflareTunnel{Name: "cf 无 Token", Enable: true, Type: "named", TunnelName: ""})
+	db.Create(&model.CloudflareTunnel{Name: "cf 停用", Enable: false, Type: "named", TunnelName: "off-tunnel"})
+	db.Create(&model.CloudflareTunnel{Name: "cf 另一无名", Enable: true, Type: "named", Token: "eyJhIjoi", TunnelName: ""})
 }
 
 func TestBuildLines(t *testing.T) {

--- a/backend/service/monitor/collector.go
+++ b/backend/service/monitor/collector.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -320,7 +321,7 @@ func (c *Collector) ProbeHTTP(probeURL string, timeout int) (bool, int64, int, e
 
 // ProbeTCP TCP 探测
 func (c *Collector) ProbeTCP(addr string, port int, timeout int) (bool, int64, error) {
-	target := fmt.Sprintf("%s:%d", addr, port)
+	target := net.JoinHostPort(addr, strconv.Itoa(port))
 	
 	start := time.Now()
 	conn, err := net.DialTimeout("tcp", target, time.Duration(timeout)*time.Second)
@@ -336,7 +337,7 @@ func (c *Collector) ProbeTCP(addr string, port int, timeout int) (bool, int64, e
 
 // ProbeUDP UDP 探测
 func (c *Collector) ProbeUDP(addr string, port int, timeout int) (bool, int64, error) {
-	target := fmt.Sprintf("%s:%d", addr, port)
+	target := net.JoinHostPort(addr, strconv.Itoa(port))
 	
 	start := time.Now()
 	conn, err := net.DialTimeout("udp", target, time.Duration(timeout)*time.Second)

--- a/backend/service/portforward/manager.go
+++ b/backend/service/portforward/manager.go
@@ -3,6 +3,7 @@ package portforward
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -124,7 +125,7 @@ func (p *TCPProxy) handleConn(src net.Conn) {
 		src.Close()
 	}()
 
-	dst, err := net.Dial("tcp", fmt.Sprintf("%s:%d", p.targetAddr, p.targetPort))
+	dst, err := net.Dial("tcp", net.JoinHostPort(p.targetAddr, strconv.Itoa(p.targetPort)))
 	if err != nil {
 		p.log.Errorf("连接目标[TCP] %s:%d 失败: %v", p.targetAddr, p.targetPort, err)
 		return

--- a/backend/service/portforward/socks5_proxy.go
+++ b/backend/service/portforward/socks5_proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -185,7 +186,7 @@ func (p *SOCKS5Proxy) handleConn(conn net.Conn) {
 		return
 	}
 	targetPort := binary.BigEndian.Uint16(portBuf)
-	fullTarget := fmt.Sprintf("%s:%d", targetAddr, targetPort)
+	fullTarget := net.JoinHostPort(targetAddr, strconv.Itoa(int(targetPort)))
 
 	// 目前只支持 CONNECT（TCP 代理）
 	if cmd != 0x01 {


### PR DESCRIPTION
## 中文

### 问题

#40 将 CF 隧道重构为 `CloudflareTunnel` 模型并重写了 API 层，但迁移没收尾，线上行为是坏的：

1. **创建后无法启动**：API 的 CRUD 写的是新表 `cloudflare_tunnels`，而 `service/cftunnel/manager.go` 的 Start/Stop/StartAll 仍读写旧表 `cftunnel_configs` —— 用户在页面创建隧道后点启动，必报「CF 隧道配置不存在」
2. **quick 入口/状态写错表**：进程退出、状态回写（status/last_error/quick_url）全部落在旧表，新表数据永远不变
3. **3 个测试在上游 main 上即失败**：`linereg_test.go` 仍用旧模型造数（`TestBuildLines`/`TestManagerRefreshWiresLines`/`TestRefreshWritesProbeHistory`，"缺少 cftunnel:1"、"期望 6 条线路 got 5"），而 `BuildLines` 已读新模型

### 修复

- `service/cftunnel/manager.go` 全面对齐 `model.CloudflareTunnel`：
  - `Mode` → `Type`，`quick_url` 列 → `public_url`
  - `buildArgs` 按新 API 语义重写：quick 用 `--url`，named 统一 Token 认证（`tunnel run --token`，与 handler 的 Create/Update 校验一致）
  - 删除旧「凭据文件/配置文件」流程的 `writeTempConfig`（新模型无对应字段）
- 删除死模型 `CftunnelConfig`（models.go 定义 + db.go autoMigrate 项；旧表留在既有用户库中不删除，无副作用）
- `linereg_test.go` 造数切换到 `CloudflareTunnel`，3 个失败测试恢复通过

### 已知遗留（不在本 PR 范围）

- 前端 `cftunnelApi` 的 `/cftunnel/binary`、`/cftunnel/download/*` 调用在 #40 删除 downloader 后已无对应后端端点（404），需要后续补回二进制下载功能
- named 隧道若配置了自定义域名（`Hostname`），linereg 线路仍按 `{tunnel}.cfargotunnel.com:443` 生成，可考虑优先用 Hostname

### 验证

- `go build` 通过；`go vet` 0 告警（含 #46 的栈内修复）
- `go test ./...` 全部通过（此前 3 个失败用例修复）
- 行为对 IPv4/quick 路径无变化；named 路径从"必失败"修复为可用

---

## English

#40 migrated CF tunnel CRUD to the new `CloudflareTunnel` model but left the service layer on the legacy `CftunnelConfig` table: create-then-start always failed (record looked up in the wrong table), status/URL writes landed on the dead table, and 3 linereg tests failed on main due to stale fixtures. This aligns `service/cftunnel/manager.go` with the new model (quick → `--url`, named → token auth, matching the handler's validation), removes the dead model + autoMigrate entry, and fixes the test fixtures. `go build`/`go vet`/`go test ./...` all clean. Known follow-ups (not in this PR): the frontend's binary-download endpoints were orphaned when downloader.go was removed in #40, and linereg could prefer the configured `Hostname` for named tunnels.