### PR TITLE
feat(waf): 新增WAF事件分析API，支持攻击类型分布、时间序列、Top IP等统计

### DIFF
--- a/backend/api/handlers/waf_analytics.go
+++ b/backend/api/handlers/waf_analytics.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/netpanel/netpanel/model"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// WafAnalyticsHandler WAF 事件分析处理器
+type WafAnalyticsHandler struct {
+	db  *gorm.DB
+	log *logrus.Logger
+}
+
+func NewWafAnalyticsHandler(db *gorm.DB, log *logrus.Logger) *WafAnalyticsHandler {
+	return &WafAnalyticsHandler{db: db, log: log}
+}
+
+// GetAnalytics 获取 WAF 分析数据
+func (h *WafAnalyticsHandler) GetAnalytics(c *gin.Context) {
+	// 查询参数
+	startStr := c.Query("start")
+	endStr := c.Query("end")
+	ruleID := c.Query("rule_id")
+	severities := c.Query("severity")
+
+	startTime := time.Now().Add(-24 * time.Hour)
+	endTime := time.Now()
+	if startStr != "" {
+		if t, err := time.Parse("2006-01-02", startStr); err == nil {
+			startTime = t
+		}
+	}
+	if endStr != "" {
+		if t, err := time.Parse("2006-01-02", endStr); err == nil {
+			endTime = t
+		}
+	}
+
+	// 基础查询
+	query := h.db.Model(&model.WafLog{}).Where("log_time BETWEEN ? AND ?", startTime, endTime)
+	if ruleID != "" {
+		query = query.Where("rule_id = ?", ruleID)
+	}
+	if severities != "" {
+		query = query.Where("severity IN (?)", severities)
+	}
+
+	// 攻击类型分布
+	type AttackType struct {
+		RuleMsg string `json:"rule_msg"`
+		Count   int64  `json:"count"`
+	}
+	var attackTypes []AttackType
+	query.Model(&model.WafLog{}).Select("rule_msg, COUNT(*) as count").Group("rule_msg").Order("count DESC").Limit(10).Find(&attackTypes)
+
+	//  severity 分布
+	type SeverityCount struct {
+		Severity string `json:"severity"`
+		Count    int64  `json:"count"`
+	}
+	var severityCounts []SeverityCount
+	query.Model(&model.WafLog{}).Select("severity, COUNT(*) as count").Group("severity").Order("count DESC").Find(&severityCounts)
+
+	// 时间序列（按小时）
+	type TimeSeriesPoint struct {
+		Timestamp string `json:"timestamp"`
+		Count     int64  `json:"count"`
+	}
+	var timeSeries []TimeSeriesPoint
+	query.Select("strftime('%Y-%m-%d %H:00', log_time) as timestamp, COUNT(*) as count").
+		Group("timestamp").
+		Order("timestamp ASC").
+		Find(&timeSeries)
+
+	// Top IP
+	type TopIP struct {
+		IP    string `json:"ip"`
+		Count int64  `json:"count"`
+	}
+	var topIPs []TopIP
+	query.Select("client_ip as ip, COUNT(*) as count").Group("client_ip").Order("count DESC").Limit(10).Find(&topIPs)
+
+	// 总数
+	var total int64
+	query.Count(&total)
+
+	c.JSON(http.StatusOK, gin.H{
+		"code": 200,
+		"data": gin.H{
+			"total":        total,
+			"attack_types": attackTypes,
+			"severities":   severityCounts,
+			"time_series":  timeSeries,
+			"top_ips":      topIPs,
+		},
+	})
+}
+
+// GetLogs 获取 WAF 日志列表（分页）
+func (h *WafAnalyticsHandler) GetLogs(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "50"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 500 {
+		pageSize = 50
+	}
+
+	query := h.db.Model(&model.WafLog{}).Order("id DESC")
+
+	// 筛选
+	if ruleID := c.Query("rule_id"); ruleID != "" {
+		query = query.Where("rule_id = ?", ruleID)
+	}
+	if action := c.Query("action"); action != "" {
+		query = query.Where("action = ?", action)
+	}
+	if severity := c.Query("severity"); severity != "" {
+		query = query.Where("severity = ?", severity)
+	}
+	if keyword := c.Query("keyword"); keyword != "" {
+		query = query.Where("rule_msg LIKE ? OR uri LIKE ?", "%"+keyword+"%", "%"+keyword+"%")
+	}
+
+	var total int64
+	query.Count(&total)
+
+	var logs []model.WafLog
+	offset := (page - 1) * pageSize
+	query.Offset(offset).Limit(pageSize).Find(&logs)
+
+	c.JSON(http.StatusOK, gin.H{
+		"code":    200,
+		"data":    logs,
+		"total":   total,
+		"page":    page,
+		"page_size": pageSize,
+	})
+}

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -419,6 +419,11 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	admin.POST("/security/waf/bans/:id/apply", wafHandler.BanApply)
 	admin.POST("/security/waf/bans/:id/remove", wafHandler.BanRemove)
 
+	// WAF 分析
+	wafAnalyticsHandler := handlers.NewWafAnalyticsHandler(opts.DB, opts.Log)
+	auth.GET("/security/waf/analytics", wafAnalyticsHandler.GetAnalytics)
+	auth.GET("/security/waf/logs", wafAnalyticsHandler.GetLogs)
+
 	// 回调账号
 	cbAccountHandler := handlers.NewCallbackAccountHandler(opts.DB, opts.Log, opts.CallbackMgr)
 	auth.GET("/callback/accounts", cbAccountHandler.List)


### PR DESCRIPTION
## 新增功能

新增WAF事件分析API接口，用于前端可视化展示WAF拦截数据：

### API端点

| 方法 | 路径 | 说明 |
|------|------|------|
| GET | /api/v1/security/waf/analytics | 获取WAF事件统计数据 |
| GET | /api/v1/security/waf/logs | 获取WAF日志列表（分页） |

### 统计数据

- **攻击类型分布**：按 rule_msg 分组统计，返回Top 10
- **Severity分布**：CRITICAL/ERROR/WARNING/NOTICE 计数
- **时间序列**：按小时统计拦截次数，支持时间范围筛选
- **Top IP**：攻击来源IP排名

### 筛选参数

- `start` / `end`：时间范围（YYYY-MM-DD格式）
- `rule_id`：规则ID
- `severity`：严重程度过滤
- `keyword`：关键词搜索

## 改动文件

- `backend/api/handlers/waf_analytics.go`: 新增WAF分析处理器
- `backend/api/router.go`: 注册新路由

## 关联Issue

- #13 (WAF事件实时分析看板)