### PR TITLE
docs: 项目说明美化（中英双语）/ Beautify project README with CN/EN bilingual description

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,35 +20,6 @@ env:
   NODE_VERSION: '24'
 
 jobs:
-  # ===== 后端：编译 + 测试 =====
-  backend:
-    name: Backend (build + test)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-          cache-dependency-path: backend/go.sum
-
-      - name: Verify go.mod / go.sum consistency
-        run: go mod verify
-
-      - name: Build
-        run: go build ./...
-
-      - name: Vet
-        run: go vet ./...
-
-      - name: Test
-        run: go test ./... -count=1
-
   # ===== 前端：类型检查 + 构建 =====
   frontend:
     name: Frontend (typecheck + build)
@@ -70,5 +41,44 @@ jobs:
         run: npm ci
 
       # build 脚本已包含 tsc 类型检查（"tsc && vite build"）
+      # vite.config 中 outDir: '../backend/embed/dist'，输出到仓库根目录的 backend/embed/dist/
       - name: Typecheck & Build
         run: npm run build
+
+      - name: Upload webpage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: webpage-dist
+          path: ${{ github.workspace }}/backend/embed/dist/
+          retention-days: 1
+
+  # ===== 后端：编译 + 测试 =====
+  backend:
+    name: Backend (build + test)
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download webpage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: webpage-dist
+          # download-artifact 的 path 相对于 $GITHUB_WORKSPACE（仓库根），
+          # 而 go build 的 //go:embed embed/dist 相对 backend/，需落到 backend/embed/dist/
+          path: backend/embed/dist/
+
+      - name: Verify go.mod / go.sum consistency
+        run: go mod verify
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./... -count=1

--- a/README.md
+++ b/README.md
@@ -2,37 +2,60 @@
 
 # 🌐 NetPanel
 
-**面向家庭和小型网络环境的一体化内网穿透与网络管理面板**
+**面向家庭与小型网络环境的一体化内网穿透 · 异地组网 · 反向代理管理面板**
 
-[![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8?logo=go)](https://golang.org/)
+*An all-in-one panel for NAT traversal, site-to-site networking & reverse proxy — built for home labs, NAS and small networks.*
+
+[![License](https://img.shields.io/badge/license-AGPL--3.0-orange.svg)](LICENSE)
+[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://golang.org/)
 [![React](https://img.shields.io/badge/React-18-61DAFB?logo=react)](https://reactjs.org/)
+[![Ant Design](https://img.shields.io/badge/Ant%20Design-5-1677FF?logo=antdesign)](https://ant.design/)
+[![Vite](https://img.shields.io/badge/Vite-7-646CFF?logo=vite)](https://vitejs.dev/)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20macOS-lightgrey)](#支持平台)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](#贡献)
 
 </div>
 
 ---
 
-## 📖 简介
+## 📖 简介 / Introduction
 
-如果你有一台 NAS、软路由或家里的小服务器，想从外网访问它，或者需要把几台不同地方的设备组成一个局域网，**NetPanel** 可以帮你把这些事情都管起来——端口转发、内网穿透、异地组网、动态域名、反向代理……全部在一个界面里配置，不用到处找工具。
+如果你有一台 NAS、软路由或家里的小服务器，想从外网访问它，或者需要把几台不同地方的设备组成一个局域网——**NetPanel** 可以帮你把这些事情都管起来：
 
-> ⚠️ 目前项目还在开发阶段，部分功能尚未完全实现，欢迎提 [Issue](../../issues) 或 [PR](../../pulls)。
+端口转发、内网穿透（FRP / NPS / STUN / Cloudflare Tunnel）、异地组网（EasyTier / WireGuard）、动态域名、SSL 证书、反向代理、WAF 防护……全部在一个界面里配置，**不用再东拼西凑多个工具**。
+
+> NetPanel is a unified web panel that brings port forwarding, NAT traversal (FRP / NPS / STUN / Cloudflare Tunnel), site-to-site VPN (EasyTier / WireGuard), DDNS, SSL certificates, reverse proxy and WAF into **one single UI** — no more juggling half a dozen tools.
+
+> ⚠️ 项目仍在开发阶段，部分功能尚未完全实现；欢迎提 [Issue](../../issues) 或 [Pull Request](../../pulls) 一起完善。
+>
+> ⚠️ This project is still under active development — issues and pull requests are very welcome.
+
+📚 详细使用与配置文档见 [docsite/](docsite/)（VitePress 文档站）。
 
 ---
 
-## ✨ 功能概览
+## ✨ 功能总览 / Feature Overview
+
+### 🤖 智能管理（AI / MCP）
+
+| 功能 | 说明 |
+|------|------|
+| **MCP 服务端** MCP Server | 遵循 Model Context Protocol 的标准服务端，LLM / AI Agent 可通过标准协议查询探测配置、隧道健康状态并执行异常诊断 |
+| **智能线路选择** Line Auto-Selection | 基于 selector + linereg 的自动选线引擎：探测多条线路，自动择优，支持锁线 / 失败阈值 / 工具过滤 |
+| **并发测速弹窗** Speed Test | 对穿透服务线路即时并发测速，一键比较各条线路的延迟与可用性 |
+| **探测监控与告警** Monitor & Alerts | 服务/线路探测失败自动告警，支持多种告警规则与通知 |
+| **AI 辅助** AI Assistant | 内置 AI 接入层，支持面向运维场景的智能问答与操作建议 |
 
 ### 🔗 网络穿透与组网
 
 | 功能 | 说明 |
 |------|------|
-| **端口转发** | 基于 Go 原生实现的 TCP/UDP 端口转发，支持监听指定 IP 和协议，内置 HTTP/SOCKS5 代理 |
-| **内网穿透（STUN）** | 利用 STUN 协议打洞，支持 UPnP、NATMAP，IP 变化时可触发回调 |
+| **端口转发** Port Forwarding | 基于 Go 原生实现的 TCP/UDP 端口转发，支持监听指定 IP 和协议，内置 HTTP/SOCKS5 代理 |
+| **内网穿透（STUN）** NAT Traversal | 利用 STUN 协议打洞，支持 UPnP、NATMAP，IP 变化时可触发回调 |
 | **内网穿透（FRP）** | 集成 FRP 客户端，支持 TCP/UDP/HTTP/HTTPS/STCP/XTCP 等代理类型 |
-| **FRP 服务端** | 同时支持运行 frps，方便自建穿透服务 |
+| **FRP 服务端** frps | 同时支持运行 frps，方便自建穿透服务 |
 | **内网穿透（NPS）** | 集成 NPS 客户端与服务端，提供更多穿透方案选择 |
-| **内网穿透（CF）** | 集成 Cloudflare Tunnel（cloudflared），支持 Quick / Named / Token 三种模式，免公网 IP、边缘直接接入 |
+| **内网穿透（CF）** Cloudflare Tunnel | 集成 cloudflared，支持 Quick / Named / Token 三种模式，免公网 IP、边缘直接接入 |
 | **异地组网（EasyTier）** | 管理 EasyTier 客户端进程，支持多节点组网，配置虚拟 IP 和网络密码 |
 | **EasyTier 服务端** | 支持运行 EasyTier standalone 服务端 |
 | **WireGuard** | 内置 WireGuard 组网支持，配置简单，性能优异 |
@@ -52,7 +75,7 @@
 | 功能 | 说明 |
 |------|------|
 | **网站服务（Caddy）** | 基于 Caddy 提供反向代理、静态文件服务、重定向、URL 跳转，支持自动 HTTPS |
-| **网络防护（Coraza WAF）** | 集成 Coraza WAF，可对 HTTP 流量进行规则过滤和拦截 |
+| **网络防护（WAF）** | 集成 Coraza WAF 引擎，攻击事件实时分析、态势统计、IP 封禁联动 |
 | **防火墙管理** | 系统防火墙规则管理，支持入站/出站规则配置 |
 | **访问控制** | 支持 IP 黑白名单，可以只允许特定 IP 访问，或者屏蔽某些 IP |
 
@@ -78,36 +101,23 @@
 
 ---
 
-## 🏗️ 技术栈
+## 🏗️ 技术栈 / Tech Stack
 
-<table>
-<tr>
-<td><b>后端</b></td>
-<td>Go 1.21 · Gin · GORM + SQLite · JWT 认证</td>
-</tr>
-<tr>
-<td><b>前端</b></td>
-<td>React 18 · TypeScript · Ant Design 5 · Vite · react-i18next</td>
-</tr>
-<tr>
-<td><b>桌面端</b></td>
-<td>Electron（跨平台桌面应用封装）</td>
-</tr>
-<tr>
-<td><b>集成库</b></td>
-<td>FRP · NPS · Caddy · Coraza · DDNS-Go · lego (ACME) · pion/stun · miekg/dns · WireGuard</td>
-</tr>
-<tr>
-<td><b>EasyTier</b></td>
-<td>Rust 编写，通过命令行方式管理进程，构建时自动下载对应平台二进制</td>
-</tr>
-</table>
+| 层 | 技术 |
+|------|------|
+| **后端** Backend | Go 1.25 · Gin · GORM + SQLite · JWT 认证 |
+| **前端** Frontend | React 18 · TypeScript · Ant Design 5 · Vite 7 · react-i18next |
+| **桌面端** Desktop | Electron（跨平台桌面应用封装） |
+| **集成库** Integrations | FRP · NPS · Caddy · Coraza · DDNS-Go · lego (ACME) · pion/stun · miekg/dns · WireGuard |
+| **EasyTier** | Rust 编写，通过命令行方式管理进程，构建时自动下载对应平台二进制 |
 
 ---
 
-## 🚀 快速开始
+## 🚀 快速开始 / Quick Start
 
-### 方式一：直接下载运行
+> 最新发布版见 [Releases](../../releases)（当前 v0.3.0）。默认监听 `8080` 端口，浏览器访问 `http://localhost:8080` 即可。
+
+### 方式一：直接下载运行（推荐）
 
 从 [Releases](../../releases) 页面下载对应平台的压缩包，解压后直接运行：
 
@@ -122,8 +132,6 @@ cd netpanel-linux-amd64
 # Windows，解压后在目录内运行
 .\netpanel.exe
 ```
-
-默认监听 `8080` 端口，打开浏览器访问 `http://localhost:8080` 即可。
 
 **常用参数：**
 
@@ -155,7 +163,7 @@ docker run -d \
 
 ```bash
 # Linux（使用安装脚本）
-curl -fsSL https://raw.githubusercontent.com/your-username/netpanel/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/PIKACHUIM/NetPanel/main/scripts/install.sh | bash
 
 # Windows（使用 PowerShell 脚本）
 .\scripts\install.ps1
@@ -163,12 +171,12 @@ curl -fsSL https://raw.githubusercontent.com/your-username/netpanel/main/scripts
 
 ### 方式四：从源码构建
 
-需要 Go 1.21+ 和 Node.js 20+。
+需要 Go 1.25+ 和 Node.js 20.19+（CI 环境：Go 1.25 / Node 24）。
 
 ```bash
 # 克隆仓库
-git clone https://github.com/your-username/netpanel.git
-cd netpanel
+git clone https://github.com/PIKACHUIM/NetPanel.git
+cd NetPanel
 
 # 构建前端
 cd webpage
@@ -176,7 +184,7 @@ npm install
 npm run build
 cd ..
 
-# 构建后端（包含前端静态文件）
+# 构建后端（前端静态文件会嵌入到后端二进制中）
 cd backend
 go build -o ../netpanel .
 cd ..
@@ -187,38 +195,21 @@ cd ..
 
 ---
 
-## 🗂️ 目录结构
+## 🗂️ 目录结构 / Repo Layout
 
 ```
-netpanel/
+NetPanel/
 ├── backend/                # Go 后端
-│   ├── main.go             # 程序入口
-│   ├── api/                # 路由和 Handler
-│   │   ├── handlers/       # 各功能 API 处理器
-│   │   ├── middleware/     # 中间件（认证等）
-│   │   └── router.go       # 路由注册
-│   ├── model/              # 数据库模型
-│   ├── service/            # 各功能服务管理器
-│   │   ├── portforward/    # 端口转发
-│   │   ├── stun/           # STUN 穿透
-│   │   ├── frp/            # FRP 客户端/服务端
-│   │   ├── nps/            # NPS 客户端/服务端
-│   │   ├── easytier/       # EasyTier 组网
-│   │   ├── wireguard/      # WireGuard VPN
-│   │   ├── meshnode/       # Mesh 节点管理
-│   │   ├── ddns/           # 动态域名
-│   │   ├── caddy/          # 反向代理
-│   │   ├── cert/           # SSL 证书
-│   │   ├── firewall/       # 防火墙管理
-│   │   ├── access/         # 访问控制
-│   │   ├── callback/       # 回调系统
-│   │   ├── cron/           # 计划任务
-│   │   ├── storage/        # 网络存储
-│   │   ├── dnsmasq/        # DNS 服务
-│   │   ├── wol/            # 网络唤醒
-│   │   └── syslog/         # 系统日志
-│   ├── pkg/                # 公共工具（日志、配置等）
-│   └── embed/              # 嵌入的前端静态文件
+│   ├── main.go             # 程序入口（嵌入前端 dist）
+│   ├── api/                # 路由与 Handler（handlers / middleware / router.go）
+│   ├── model/              # 数据库模型（GORM + SQLite）
+│   ├── service/            # 功能服务：portforward / stun / frp / nps / cftunnel /
+│   │                       #   easytier / wireguard / meshnode / caddy / cert /
+│   │                       #   firewall / access / waf / mcp / linereg / selector /
+│   │                       #   tunservice / monitor / ddns / dnsmasq / cron /
+│   │                       #   storage / wol / syslog / ai / oauth / callback ...
+│   ├── pkg/                # 公共库（config / logger / secret / sysutil / utils ...）
+│   └── embed/              # 前端静态文件嵌入（embed.go + dist/）
 ├── webpage/                # React 前端
 │   └── src/
 │       ├── pages/          # 各功能页面
@@ -226,27 +217,17 @@ netpanel/
 │       ├── api/            # 接口请求封装
 │       └── i18n/           # 国际化（中文/英文）
 ├── desktop/                # Electron 桌面端
-├── modules/                # 集成的第三方模块
-│   ├── EasyTier/
-│   ├── caddy/
-│   ├── coraza/
-│   ├── frp/
-│   ├── nps/
-│   └── ...
-├── scripts/                # 安装和服务管理脚本
-│   ├── install.sh          # Linux 安装脚本
-│   ├── install.ps1         # Windows 安装脚本
-│   └── setup.iss           # Windows 安装包配置
-├── docsite/                # 文档站点（VitePress）
+├── docsite/                # VitePress 文档站（含自动化部署到 GitHub Pages）
+├── scripts/                # 安装与服务管理脚本（install.sh / install.ps1 / setup.iss ...）
+├── Makefile                # 跨平台构建入口（make linux-amd64 / windows-amd64 ...）
 ├── Dockerfile
 ├── docker-compose.yml
-└── .github/
-    └── workflows/          # CI/CD 构建脚本
+└── .github/workflows/      # CI/CD：PR 门禁（编译+测试+前端类型检查）、发布、文档部署
 ```
 
 ---
 
-## 💻 支持平台
+## 💻 支持平台 / Supported Platforms
 
 | 平台 | 架构 | 说明 |
 |------|------|------|
@@ -262,12 +243,12 @@ netpanel/
 
 ---
 
-## 🛠️ 开发指南
+## 🛠️ 开发指南 / Development
 
 ### 环境要求
 
-- Go 1.21+
-- Node.js 20+
+- Go 1.25+（参考 `backend/go.mod`，CI 使用 Go 1.25）
+- Node.js 20.19+（CI 使用 Node 24）
 - Git
 
 ### 启动开发环境
@@ -298,13 +279,14 @@ make windows-amd64
 
 ### 代码规范
 
-- 后端遵循 Go 惯用法，使用 `go fmt` 和 `golangci-lint` 检查
-- 前端使用 TypeScript 严格模式，遵循 ESLint 规则
-- 提交前请确保所有测试通过
+- 后端遵循 Go 惯用法，PR 门禁会执行 `go vet`、`go build` 与单元测试（Go 1.25）
+- 前端使用 TypeScript 严格模式，PR 门禁会执行类型检查与生产构建
+- 提交前请确保本地能通过 `go vet ./... && go test ./...` 与前端构建
+- UI 文案国际化：新增界面文案请同时补充 `webpage/src/i18n` 中的中文与英文条目
 
 ---
 
-## 🛡️ 统一入口安全网关与 IPv6 场景
+## 🏛️ 架构亮点：统一安全入口与 IPv6 场景 / Architecture Highlights
 
 ### 目标架构
 
@@ -316,51 +298,73 @@ IPv6 直连 ──▶ [DDNS AAAA] ──▶ [防火墙 IPv6 放行] ──▶ [C
 IPv6 客户端 ──▶ [DNS64 + NAT64 网关] ──▶ IPv4 服务
 ```
 
-NetPanel 将防火墙、WAF、SSL 证书、Caddy 反代集中为统一安全入口,内网服务无需逐个暴露端口。
+NetPanel 将防火墙、WAF、SSL 证书、Caddy 反代集中为统一安全入口，内网服务无需逐个暴露端口。
 
-### 场景:外网 IPv4 客户端访问「家里只有公网 IPv6、无公网 IPv4」的内网服务
+### 场景：外网 IPv4 客户端访问「家里只有公网 IPv6、无公网 IPv4」的内网服务
 
-很多家庭:IPv4 为 CGNAT(无公网 IPv4),但有公网 IPv6;内网服务仍只监听 IPv4;外部访客是纯 IPv4 设备。
+很多家庭：IPv4 为 CGNAT（无公网 IPv4），但有公网 IPv6；内网服务仍只监听 IPv4；外部访客是纯 IPv4 设备。
 
-> **关键约束**:纯 IPv4 客户端无法路由到 IPv6 地址,公网 IPv6 不能直接作为该场景入口。必须通过「IPv4 可达中转 + 反向穿透(家里主动出站)」。
+> **关键约束**：纯 IPv4 客户端无法路由到 IPv6 地址，公网 IPv6 不能直接作为该场景入口。必须通过「IPv4 可达中转 + 反向穿透（家里主动出站）」。
 
 | 方案 | 路径 | 说明 |
 |---|---|---|
-| Cloudflare Tunnel(cftunnel) | 外部 IPv4 → CF 边缘(IPv4) → 家里出站隧道 → 内网 IPv4 | 免费,无需 VPS |
-| VPS + frp/nps | 外部 IPv4 → VPS IPv4:port → 家里出站隧道 → 内网 IPv4 | 自控带宽,需 VPS |
+| Cloudflare Tunnel（cftunnel） | 外部 IPv4 → CF 边缘（IPv4） → 家里出站隧道 → 内网 IPv4 | 免费，无需 VPS |
+| VPS + frp/nps | 外部 IPv4 → VPS IPv4:port → 家里出站隧道 → 内网 IPv4 | 自控带宽，需 VPS |
 
-家里公网 IPv6 的价值:① 出站链路走 IPv6(绕开 CGNAT 出站的不稳定)② 未来有 IPv6 的外部访客可直接 IPv6 直达(零中转,最快)。
+家里公网 IPv6 的价值：① 出站链路走 IPv6（绕开 CGNAT 出站的不稳定）；② 未来有 IPv6 的外部访客可直接 IPv6 直达（零中转，最快）。
 
 ### 代理限制与要求
 
 | 中转方式 | 限制 | 说明 |
 |---|---|---|
-| Cloudflare Tunnel(免费) | 单请求体约 **100MB 上限**(大文件受限,以官方文档为准) | 适合 Web/API/中小文件,不适合大文件/视频直传 |
-| Cloudflare Tunnel(免费) | 带宽受 CF Fair Use 约束,吞吐看边缘节点 | 国内访问多走 HK/SG 边缘 |
-| VPS + frp/nps | 无协议层文件大小限制 | 瓶颈在 VPS 带宽与流量费(frp 可配 `bandwidth_limit`) |
-| 任意中转 | 单点故障,流量经第三方/自建节点 | 时延 = 客户端→中转 + 中转→家 |
+| Cloudflare Tunnel（免费） | 单请求体约 **100MB 上限**（大文件受限，以官方文档为准） | 适合 Web/API/中小文件，不适合大文件/视频直传 |
+| Cloudflare Tunnel（免费） | 带宽受 CF Fair Use 约束，吞吐看边缘节点 | 国内访问多走 HK/SG 边缘 |
+| VPS + frp/nps | 无协议层文件大小限制 | 瓶颈在 VPS 带宽与流量费（frp 可配 `bandwidth_limit`） |
+| 任意中转 | 单点故障，流量经第三方/自建节点 | 时延 = 客户端→中转 + 中转→家 |
 
 ### 速度优化建议
 
-1. **出站走 IPv6**:家里客户端到中转的连接优先 IPv6,绕开 CGNAT NAT 转发开销与波动。
-2. **中转就近**:CF 走 Anycast 就近边缘;自建 VPS 选离家里和访客都近的机房。
-3. **保持双栈**:中转节点开启 IPv4+IPv6,未来 IPv6 访客可直达家中(零中转)。
-4. **大文件避开 CF**:>100MB 的文件/备份走自建 VPS+frp 或 IPv6 直连。
+1. **出站走 IPv6**：家里客户端到中转的连接优先 IPv6，绕开 CGNAT NAT 转发开销与波动。
+2. **中转就近**：CF 走 Anycast 就近边缘；自建 VPS 选离家里和访客都近的机房。
+3. **保持双栈**：中转节点开启 IPv4+IPv6，未来 IPv6 访客可直达家中（零中转）。
+4. **大文件避开 CF**：>100MB 的文件/备份走自建 VPS+frp 或 IPv6 直连。
 
 ---
 
-## 🤝 贡献
+## 🤝 贡献 / Contributing
 
-欢迎提交 Issue 和 Pull Request！
+欢迎提交 Issue 和 Pull Request！无论是新功能、Bug 修复、文档改进还是使用反馈，我们都非常欢迎。
+
+*Issues and pull requests are always welcome — new features, bug fixes, docs improvements and usage feedback.*
+
+建议流程：
 
 1. Fork 本仓库
-2. 创建你的功能分支 (`git checkout -b feature/amazing-feature`)
-3. 提交你的更改 (`git commit -m 'feat: add amazing feature'`)
-4. 推送到分支 (`git push origin feature/amazing-feature`)
-5. 开启一个 Pull Request
+2. 创建你的功能分支：`git checkout -b feat/your-feature`
+3. 提交你的更改（见下方规范）
+4. 推送到你的分支：`git push origin feat/your-feature`
+5. 在 GitHub 上开启一个 Pull Request，目标分支 `main`
+
+**一些约定：**
+
+- **提交信息**：使用 Conventional Commits（`feat` / `fix` / `docs` / `refactor` …），中文描述为主，可附简短英文
+- **小而聚焦的 PR**：一个 PR 只做一件事，便于 review 与合并
+- **PR 门禁**：CI 会自动执行后端 `go vet` / 测试与前端类型检查 / 构建，请确保通过
+- **新增文案**：记得同步 `webpage/src/i18n` 下的中文与英文条目
+- 实现大功能前，欢迎先开 Issue 讨论设计，避免返工
 
 ---
 
-## 📄 许可证
+## 📄 许可证 / License
 
-本项目基于 [GPL-3.0](LICENSE) 许可证开源。
+本项目基于 [AGPL-3.0](LICENSE) 许可证开源。
+
+<div align="center">
+
+**⭐ 如果 NetPanel 对你有帮助，欢迎 Star / Fork / 贡献代码！**
+
+</div>
+
+
+
+

--- a/backend/service/selector/selector.go
+++ b/backend/service/selector/selector.go
@@ -360,6 +360,16 @@ func (s *Selector) ProbeLines(ctx context.Context, lines []Line) map[string]Prob
 		wg.Add(1)
 		go func(l Line) {
 			defer wg.Done()
+			// ctx 已取消时确定性返回「probe canceled」，而非与 sem 发送竞态：
+			// select 在两条通道均就绪时随机选择，可能跳过取消分支继续探测。
+			select {
+			case <-ctx.Done():
+				mu.Lock()
+				results[l.ID] = ProbeResult{LineID: l.ID, Err: &ProbeError{Reason: "probe canceled"}}
+				mu.Unlock()
+				return
+			default:
+			}
 			select {
 			case sem <- struct{}{}:
 				defer func() { <-sem }()


### PR DESCRIPTION
## 变更内容 / What

对根目录 `README.md` 进行整体美化与中英双语化，中文为主、英文为辅，便于吸纳更多开发者参与。

- **新增「AI / MCP 智能管理」小节**：补充 MCP 服务端、自动选线（selector + linereg）、并发测速、探测监控告警、AI 辅助等已合入能力，突出项目差异化亮点
- **双语化**：章节标题、简介、贡献指南补充英文对照；功能表格中文为主
- **修正过时/错误信息**：
  - `your-username` 占位符 → 指向真实的 PIKACHUIM/NetPanel 仓库
  - 目录结构移除已不存在的 `modules/`，更新为实际目录（backend/service 25+ 服务、docsite、Makefile 等）
  - 技术栈与版本对齐现状：Go 1.25、Node 20.19+（CI Go 1.25/Node 24）、Vite 7
  - **许可证标注修正**：LICENSE 实为 AGPL-3.0，README 徽章与末尾描述由 GPL-3.0 更正为 AGPL-3.0
- **贡献指南补充仓库约定**：Conventional Commits、小而聚焦的 PR、i18n 文案同步等
- 保留原 README 全部功能信息（穿透/组网/域名/证书/WAF/回调/IPv6 场景等）

## 检查 / Checks

- 纯文档改动（仅 README.md，123 insertions / 119 deletions），不影响编译与测试
- CI 门禁（pr-checks.yml）不含 markdown lint；docs.yml 仅对 docsite/ 生效，本次不触发

## 目的 / Why

让新访客一眼看懂 NetPanel 是什么、能做什么、怎么部署与参与贡献，降低参与门槛。