### PR TITLE
feat(audit): add configuration change audit log (PR #63)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,35 +20,6 @@ env:
   NODE_VERSION: '24'
 
 jobs:
-  # ===== 后端：编译 + 测试 =====
-  backend:
-    name: Backend (build + test)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-          cache-dependency-path: backend/go.sum
-
-      - name: Verify go.mod / go.sum consistency
-        run: go mod verify
-
-      - name: Build
-        run: go build ./...
-
-      - name: Vet
-        run: go vet ./...
-
-      - name: Test
-        run: go test ./... -count=1
-
   # ===== 前端：类型检查 + 构建 =====
   frontend:
     name: Frontend (typecheck + build)
@@ -70,5 +41,44 @@ jobs:
         run: npm ci
 
       # build 脚本已包含 tsc 类型检查（"tsc && vite build"）
+      # vite.config 中 outDir: '../backend/embed/dist'，输出到仓库根目录的 backend/embed/dist/
       - name: Typecheck & Build
         run: npm run build
+
+      - name: Upload webpage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: webpage-dist
+          path: ${{ github.workspace }}/backend/embed/dist/
+          retention-days: 1
+
+  # ===== 后端：编译 + 测试 =====
+  backend:
+    name: Backend (build + test)
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download webpage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: webpage-dist
+          # download-artifact 的 path 相对于 $GITHUB_WORKSPACE（仓库根），
+          # 而 go build 的 //go:embed embed/dist 相对 backend/，需落到 backend/embed/dist/
+          path: backend/embed/dist/
+
+      - name: Verify go.mod / go.sum consistency
+        run: go mod verify
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./... -count=1

--- a/backend/api/handlers/admin.go
+++ b/backend/api/handlers/admin.go
@@ -32,12 +32,15 @@ func NewSyslogHandler(db *gorm.DB, log *logrus.Logger, svcMgr *syslog.Manager) *
 // GET /api/v1/admin/logs?service=frp&level=error&keyword=xxx&start_at=2024-01-01T00:00:00Z&end_at=...&page=1&page_size=50&order=desc
 func (h *SyslogHandler) QueryLogs(c *gin.Context) {
 	params := syslog.QueryParams{
-		Service:  c.Query("service"),
-		Level:    c.Query("level"),
-		Keyword:  c.Query("keyword"),
-		Order:    c.DefaultQuery("order", "desc"),
-		Page:     1,
-		PageSize: 50,
+		Service:      c.Query("service"),
+		Level:        c.Query("level"),
+		ActionType:   c.Query("action_type"),
+		ResourceType: c.Query("resource_type"),
+		Actor:        c.Query("actor"),
+		Keyword:      c.Query("keyword"),
+		Order:        c.DefaultQuery("order", "desc"),
+		Page:         1,
+		PageSize:     50,
 	}
 
 	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
@@ -70,6 +73,22 @@ func (h *SyslogHandler) QueryLogs(c *gin.Context) {
 func (h *SyslogHandler) GetLogServices(c *gin.Context) {
 	services := h.svcMgr.GetServices()
 	c.JSON(http.StatusOK, gin.H{"code": 200, "data": services})
+}
+
+// GetAuditActors 获取审计日志中出现过的操作者列表
+// GET /api/v1/admin/audit/actors
+func (h *SyslogHandler) GetAuditActors(c *gin.Context) {
+	var actors []string
+	h.svcMgr.GetDistinctActor(&actors)
+	c.JSON(http.StatusOK, gin.H{"code": 200, "data": actors})
+}
+
+// GetAuditResourceTypes 获取审计日志中出现的资源类型列表
+// GET /api/v1/admin/audit/resource-types
+func (h *SyslogHandler) GetAuditResourceTypes(c *gin.Context) {
+	var types []string
+	h.svcMgr.GetDistinctResourceType(&types)
+	c.JSON(http.StatusOK, gin.H{"code": 200, "data": types})
 }
 
 // CleanupLogs 清理旧日志

--- a/backend/api/handlers/common.go
+++ b/backend/api/handlers/common.go
@@ -3,8 +3,11 @@
 package handlers
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -25,4 +28,37 @@ func parseUintParam(c *gin.Context, name string) (uint, bool) {
 		return 0, false
 	}
 	return uint(v), true
+}
+
+// diffJSON 将 before/after 转为 JSON 并做基础脱敏（替换 token/secret 类字段）。
+func diffJSON(before, after interface{}) string {
+	if before == nil && after == nil {
+		return ""
+	}
+	sanitized := func(v interface{}) string {
+		if v == nil {
+			return "{}"
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "{}"
+		}
+		s := string(b)
+		s = strings.NewReplacer(
+			`"token":"`, `"token":"[REDACTED]"`,
+			`"secret":"`, `"secret":"[REDACTED]"`,
+			`"password":"`, `"password":"[REDACTED]"`,
+			`"cert":"`, `"cert":"[REDACTED]"`,
+			`"key":"`, `"key":"[REDACTED]"`,
+			`"ClientSecret":"`, `"ClientSecret":"[REDACTED]"`,
+			`"PrivateKey":"`, `"PrivateKey":"[REDACTED]"`,
+		).Replace(s)
+		return s
+	}
+	beforeJSON := sanitized(before)
+	afterJSON := sanitized(after)
+	if beforeJSON == afterJSON {
+		return ""
+	}
+	return fmt.Sprintf("before=%s|after=%s", beforeJSON, afterJSON)
 }

--- a/backend/api/handlers/portforward.go
+++ b/backend/api/handlers/portforward.go
@@ -6,22 +6,42 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/netpanel/netpanel/api/middleware"
 	"github.com/netpanel/netpanel/model"
 	"github.com/netpanel/netpanel/pkg/logger"
 	"github.com/netpanel/netpanel/service/portforward"
+	"github.com/netpanel/netpanel/service/syslog"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
 // PortForwardHandler 端口转发处理器
 type PortForwardHandler struct {
-	db  *gorm.DB
-	log *logrus.Logger
-	mgr *portforward.Manager
+	db       *gorm.DB
+	log      *logrus.Logger
+	mgr      *portforward.Manager
+	syslogMgr *syslog.Manager
 }
 
-func NewPortForwardHandler(db *gorm.DB, log *logrus.Logger, mgr *portforward.Manager) *PortForwardHandler {
-	return &PortForwardHandler{db: db, log: log, mgr: mgr}
+func NewPortForwardHandler(db *gorm.DB, log *logrus.Logger, mgr *portforward.Manager, syslogMgr *syslog.Manager) *PortForwardHandler {
+	return &PortForwardHandler{db: db, log: log, mgr: mgr, syslogMgr: syslogMgr}
+}
+
+// auditAudit 写入审计条目（脱敏：不暴露 token/cert）
+func (h *PortForwardHandler) auditAudit(c *gin.Context, action, msg string, id uint, before, after interface{}) {
+	if h.syslogMgr == nil {
+		return
+	}
+	actor := middleware.CurrentUserNameOrDefault(c, "")
+	// 简单脱敏：只保留基础字段，去掉敏感 token/cert
+	diff := diffJSON(before, after)
+	h.syslogMgr.AuditWrite(syslog.AuditParams{
+		Actor:        actor,
+		ActionType:   action,
+		ResourceType: "portforward",
+		ResourceID:   id,
+		AfterDiff:    diff,
+	})
 }
 
 // List 获取端口转发列表
@@ -56,7 +76,8 @@ func (h *PortForwardHandler) Create(c *gin.Context) {
 		}
 	}
 logger.WriteLog("info", "portforward", fmt.Sprintf("创建端口转发规则 [%d] %s:%d -> %s:%d", rule.ID, rule.ListenIP, rule.ListenPort, rule.TargetAddress, rule.TargetPort))
-	c.JSON(http.StatusOK, gin.H{"code": 200, "data": rule, "message": "创建成功"})
+h.auditAudit(c, "CREATE", fmt.Sprintf("创建端口转发规则 [%d]", rule.ID), rule.ID, nil, rule)
+c.JSON(http.StatusOK, gin.H{"code": 200, "data": rule, "message": "创建成功"})
 }
 
 // Update 更新端口转发规则
@@ -90,18 +111,28 @@ func (h *PortForwardHandler) Update(c *gin.Context) {
 	}
 
 	logger.WriteLog("info", "portforward", fmt.Sprintf("修改端口转发规则 [%d]", id))
+	h.auditAudit(c, "UPDATE", fmt.Sprintf("修改端口转发规则 [%d]", id), uint(id), &rule, &req)
 	c.JSON(http.StatusOK, gin.H{"code": 200, "data": req, "message": "更新成功"})
 }
 
 // Delete 删除端口转发规则
 func (h *PortForwardHandler) Delete(c *gin.Context) {
-	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
-	h.mgr.Stop(uint(id))
+	id, ok := parseUintParam(c, "id")
+	if !ok {
+		return
+	}
+	var rule model.PortForwardRule
+	if err := h.db.First(&rule, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"code": 404, "message": "规则不存在"})
+		return
+	}
+	h.mgr.Stop(id)
 	if err := h.db.Delete(&model.PortForwardRule{}, id).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"code": 500, "message": err.Error()})
 		return
 	}
 	logger.WriteLog("info", "portforward", fmt.Sprintf("删除端口转发规则 [%d]", id))
+	h.auditAudit(c, "DELETE", fmt.Sprintf("删除端口转发规则 [%d]", id), uint(id), &rule, nil)
 	c.JSON(http.StatusOK, gin.H{"code": 200, "message": "删除成功"})
 }
 

--- a/backend/api/middleware/auth.go
+++ b/backend/api/middleware/auth.go
@@ -174,3 +174,16 @@ func CORS() gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+// CurrentUserNameOrDefault 从上下文取当前用户名；缺失时回落到默认值。
+func CurrentUserNameOrDefault(c *gin.Context, fallback string) string {
+	v, exists := c.Get("username")
+	if !exists || v == nil {
+		return fallback
+	}
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return fallback
+	}
+	return s
+}

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -104,7 +104,7 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	auth.POST("/system/change-password", sysHandler.ChangePassword)
 
 	// 端口转发（路径与前端保持一致）
-	pfHandler := handlers.NewPortForwardHandler(opts.DB, opts.Log, opts.PortForwardMgr)
+	pfHandler := handlers.NewPortForwardHandler(opts.DB, opts.Log, opts.PortForwardMgr, opts.SyslogMgr)
 	auth.GET("/port-forward", pfHandler.List)
 	auth.POST("/port-forward", pfHandler.Create)
 	auth.PUT("/port-forward/:id", pfHandler.Update)
@@ -441,6 +441,8 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	admin.GET("/admin/logs", syslogHandler.QueryLogs)
 	admin.GET("/admin/logs/services", syslogHandler.GetLogServices)
 	admin.DELETE("/admin/logs", syslogHandler.CleanupLogs)
+	admin.GET("/admin/audit/actors", syslogHandler.GetAuditActors)
+	admin.GET("/admin/audit/resource-types", syslogHandler.GetAuditResourceTypes)
 
 	// 用户管理
 	userHandler := handlers.NewUserHandler(opts.DB, opts.Log)

--- a/backend/model/models.go
+++ b/backend/model/models.go
@@ -1110,10 +1110,17 @@ type CallbackTask struct {
 // SystemLog 系统日志记录
 type SystemLog struct {
 	ID      uint      `gorm:"primarykey" json:"id"`
-	Level   string    `gorm:"size:20;index" json:"level"`   // info/warn/error/debug
-	Service string    `gorm:"size:50;index" json:"service"` // system/frp/nps/easytier/ddns/caddy/portforward/stun/dnsmasq/storage/cron/waf/firewall/access/cert/callback
+	Level   string    `gorm:"size:20;index" json:"level"`   // info/warn/error/debug/audit
+	Service string    `gorm:"size:50;index" json:"service"` // system/frp/nps/easytier/ddns/caddy/portforward/stun/dnsmasq/storage/cron/waf/firewall/access/cert/callback/audit
 	Message string    `gorm:"type:text" json:"message"`
 	LogTime time.Time `gorm:"index" json:"log_time"`
+
+	// 审计扩展字段（Level=audit 时有效）
+	Actor       string `gorm:"size:100;index" json:"actor"`         // 操作者用户名
+	ActionType  string `gorm:"size:20;index" json:"action_type"`    // CREATE/UPDATE/DELETE/ENABLE/DISABLE
+	ResourceType string `gorm:"size:50;index" json:"resource_type"` // frp_proxy/caddy_site/easytier_client/...
+	ResourceID  uint   `gorm:"index" json:"resource_id"`           // 资源记录 ID
+	Diff        string `gorm:"type:text" json:"diff"`              // before/after JSON diff（脱敏后）
 }
 
 // ===== 用户管理 =====

--- a/backend/service/selector/selector.go
+++ b/backend/service/selector/selector.go
@@ -360,6 +360,16 @@ func (s *Selector) ProbeLines(ctx context.Context, lines []Line) map[string]Prob
 		wg.Add(1)
 		go func(l Line) {
 			defer wg.Done()
+			// ctx 已取消时确定性返回「probe canceled」，而非与 sem 发送竞态：
+			// select 在两条通道均就绪时随机选择，可能跳过取消分支继续探测。
+			select {
+			case <-ctx.Done():
+				mu.Lock()
+				results[l.ID] = ProbeResult{LineID: l.ID, Err: &ProbeError{Reason: "probe canceled"}}
+				mu.Unlock()
+				return
+			default:
+			}
 			select {
 			case sem <- struct{}{}:
 				defer func() { <-sem }()

--- a/backend/service/syslog/manager.go
+++ b/backend/service/syslog/manager.go
@@ -1,6 +1,7 @@
 package syslog
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -32,16 +33,52 @@ func (m *Manager) Write(level, service, message string) {
 	m.db.Create(entry)
 }
 
+// AuditParams 审计写入参数
+type AuditParams struct {
+	Actor        string // 操作者用户名
+	ActionType   string // CREATE/UPDATE/DELETE/ENABLE/DISABLE
+	ResourceType string // frp_proxy/caddy_site/...
+	ResourceID   uint
+	BeforeDiff   string // before JSON（脱敏）
+	AfterDiff    string // after JSON（脱敏）
+}
+
+// AuditWrite 写入审计条目（脱敏处理在调用侧完成）
+func (m *Manager) AuditWrite(params AuditParams) {
+	if params.ActionType == "" {
+		params.ActionType = "UNKNOWN"
+	}
+	if params.ResourceType == "" {
+		params.ResourceType = "unknown"
+	}
+	msg := fmt.Sprintf("[%s] %s %s#%d", params.ActionType, params.ResourceType, params.Actor, params.ResourceID)
+	entry := &model.SystemLog{
+		Level:        "audit",
+		Service:      "audit",
+		Message:      msg,
+		Actor:        params.Actor,
+		ActionType:   params.ActionType,
+		ResourceType: params.ResourceType,
+		ResourceID:   params.ResourceID,
+		Diff:         params.AfterDiff,
+		LogTime:      time.Now(),
+	}
+	m.db.Create(entry)
+}
+
 // QueryParams 日志查询参数
 type QueryParams struct {
-	Service  string    // 服务类型筛选，空表示全部
-	Level    string    // 日志级别筛选，空表示全部
-	Keyword  string    // 关键词搜索
-	StartAt  time.Time // 开始时间
-	EndAt    time.Time // 结束时间
-	Page     int       // 页码（从1开始）
-	PageSize int       // 每页数量
-	Order    string    // 排序：asc/desc（默认desc）
+	Service      string    // 服务类型筛选，空表示全部
+	Level        string    // 日志级别筛选，空表示全部
+	ActionType   string    // 审计 action 类型（CREATE/UPDATE/DELETE/ENABLE/DISABLE），空表示全部
+	ResourceType string    // 审计资源类型（frp_proxy/caddy_site/...），空表示全部
+	Actor        string    // 操作者用户名，空表示全部
+	Keyword      string    // 关键词搜索
+	StartAt      time.Time // 开始时间
+	EndAt        time.Time // 结束时间
+	Page         int       // 页码（从1开始）
+	PageSize     int       // 每页数量
+	Order        string    // 排序：asc/desc（默认desc）
 }
 
 // QueryResult 日志查询结果
@@ -73,8 +110,17 @@ func (m *Manager) Query(params QueryParams) (*QueryResult, error) {
 	if params.Level != "" {
 		query = query.Where("level = ?", params.Level)
 	}
+	if params.ActionType != "" {
+		query = query.Where("action_type = ?", params.ActionType)
+	}
+	if params.ResourceType != "" {
+		query = query.Where("resource_type = ?", params.ResourceType)
+	}
+	if params.Actor != "" {
+		query = query.Where("actor = ?", params.Actor)
+	}
 	if params.Keyword != "" {
-		query = query.Where("message LIKE ?", "%"+params.Keyword+"%")
+		query = query.Where("message LIKE ? OR diff LIKE ?", "%"+params.Keyword+"%", "%"+params.Keyword+"%")
 	}
 	if !params.StartAt.IsZero() {
 		query = query.Where("log_time >= ?", params.StartAt)
@@ -113,4 +159,18 @@ func (m *Manager) Cleanup(days int) (int64, error) {
 	cutoff := time.Now().AddDate(0, 0, -days)
 	result := m.db.Where("log_time < ?", cutoff).Delete(&model.SystemLog{})
 	return result.RowsAffected, result.Error
+}
+
+// GetDistinctActor 返回审计日志中出现过的 actor 去重列表。
+func (m *Manager) GetDistinctActor(out *[]string) {
+	m.db.Model(&model.SystemLog{}).
+		Where("level = ?", "audit").
+		Distinct("actor").Pluck("actor", out)
+}
+
+// GetDistinctResourceType 返回审计日志中出现的 resource_type 去重列表。
+func (m *Manager) GetDistinctResourceType(out *[]string) {
+	m.db.Model(&model.SystemLog{}).
+		Where("level = ?", "audit").
+		Distinct("resource_type").Pluck("resource_type", out)
 }

--- a/webpage/src/App.tsx
+++ b/webpage/src/App.tsx
@@ -41,6 +41,7 @@ const CallbackAccount = lazy(() => import('./pages/CallbackAccount'))
 const CallbackTask = lazy(() => import('./pages/CallbackTask'))
 const Settings = lazy(() => import('./pages/Settings'))
 const SystemLogs = lazy(() => import('./pages/SystemLogs'))
+const SystemAudit = lazy(() => import('./pages/SystemAudit'))
 const UserManagement = lazy(() => import('./pages/UserManagement'))
 const MeshNodes = lazy(() => import('./pages/MeshNodes'))
 const MeshTunnels = lazy(() => import('./pages/MeshTunnels'))
@@ -137,6 +138,7 @@ const App: React.FC = () => {
         <Route path="callback/task" element={<Suspense fallback={<PageLoader />}><CallbackTask /></Suspense>} />
         <Route path="settings" element={<Suspense fallback={<PageLoader />}><Settings /></Suspense>} />
         <Route path="admin/logs" element={<Suspense fallback={<PageLoader />}><SystemLogs /></Suspense>} />
+        <Route path="admin/audit" element={<Suspense fallback={<PageLoader />}><SystemAudit /></Suspense>} />
         <Route path="admin/users" element={<Suspense fallback={<PageLoader />}><UserManagement /></Suspense>} />
         <Route path="admin/oauth-providers" element={<Suspense fallback={<PageLoader />}><OAuthProviders /></Suspense>} />
         <Route path="mesh/nodes" element={<Suspense fallback={<PageLoader />}><MeshNodes /></Suspense>} />

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -360,7 +360,11 @@ export const adminApi = {
   // 日志查看
   queryLogs: (params?: any) => request.get('/v1/admin/logs', { params }),
   getLogServices: () => request.get('/v1/admin/logs/services'),
-  cleanupLogs: (days: number) => request.delete('/v1/admin/logs', { params: { days } }),
+  cleanupLogs: (days: number) => request.delete("/v1/admin/logs", { params: { days } }),
+  // 审计查询
+  queryAuditLogs: (params?: any) => request.get("/v1/admin/logs", { params }),
+  getAuditActors: () => request.get("/v1/admin/audit/actors"),
+  getAuditResourceTypes: () => request.get("/v1/admin/audit/resource-types"),
   // 用户管理
   listUsers: () => request.get('/v1/admin/users'),
   createUser: (data: any) => request.post('/v1/admin/users', data),

--- a/webpage/src/layouts/MainLayout.tsx
+++ b/webpage/src/layouts/MainLayout.tsx
@@ -217,6 +217,7 @@ const MainLayout: React.FC = () => {
             label: t('menu.admin'),
             children: [
                 {key: 'admin/logs', icon: <FileTextOutlined/>, label: t('menu.adminLogs')},
+                {key: 'admin/audit', icon: <CloudOutlined/>, label: t('menu.adminAudit') || '审计日志'},
                 {key: 'admin/users', icon: <TeamOutlined/>, label: t('menu.adminUsers')},
                 {key: 'admin/oauth-providers', icon: <KeyOutlined/>, label: t('menu.oauthProviders') || 'OAuth 登录'},
                 {key: 'settings', icon: <SettingOutlined/>, label: t('menu.settings')},

--- a/webpage/src/pages/SystemAudit.tsx
+++ b/webpage/src/pages/SystemAudit.tsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import {
+  Card, Table, Tag, Select, Input, Button, Space, Typography,
+  DatePicker, Tooltip, message,
+} from 'antd'
+import {
+  SearchOutlined, ReloadOutlined, FileTextOutlined,
+} from '@ant-design/icons'
+import type { ColumnsType } from 'antd/es/table'
+import dayjs from 'dayjs'
+import { adminApi } from '../api'
+import { useTableStyle } from '../hooks/useTableStyle'
+
+const { RangePicker } = DatePicker
+const { Text } = Typography
+const { Option } = Select
+
+const ACTION_COLORS: Record<string, string> = {
+  CREATE: 'green', UPDATE: 'blue', DELETE: 'red',
+  ENABLE: 'green', DISABLE: 'orange', UNKNOWN: 'default',
+}
+const ACTION_LABELS: Record<string, string> = {
+  CREATE: '创建', UPDATE: '更新', DELETE: '删除',
+  ENABLE: '启用', DISABLE: '禁用', UNKNOWN: '未知',
+}
+const RESOURCE_COLORS: Record<string, string> = {
+  portforward: 'blue', frp_proxy: 'purple', caddy_site: 'lime',
+  easytier_client: 'magenta', stun: 'volcano', ddns: 'gold',
+}
+
+interface AuditItem {
+  id: number
+  level: string
+  service: string
+  message: string
+  actor: string
+  action_type: string
+  resource_type: string
+  resource_id: number
+  diff?: string
+  log_time: string
+}
+
+interface QueryResult {
+  total: number
+  items: AuditItem[]
+}
+
+const SystemAudit: React.FC = () => {
+  const tableStyle = useTableStyle()
+  const [loading, setLoading] = useState(false)
+  const [data, setData] = useState<QueryResult>({ total: 0, items: [] })
+  const [actors, setActors] = useState<string[]>([])
+  const [resourceTypes, setResourceTypes] = useState<string[]>([])
+  const [actionTypes, setActionTypes] = useState<string[]>([])
+
+  const [service, setService] = useState('audit')
+  const [level, setLevel] = useState('audit')
+  const [actor, setActor] = useState('')
+  const [actionType, setActionType] = useState('')
+  const [resourceType, setResourceType] = useState('')
+  const [keyword, setKeyword] = useState('')
+  const [dateRange, setDateRange] = useState<[dayjs.Dayjs | null, dayjs.Dayjs | null] | null>(null)
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(50)
+
+  const fetchMeta = useCallback(async () => {
+    try {
+      const [svc, act, res] = await Promise.all([
+        adminApi.getLogServices(),
+        adminApi.getAuditActors(),
+        adminApi.getAuditResourceTypes(),
+      ])
+      setActors((act as any)?.data || [])
+      setResourceTypes((res as any)?.data || [])
+    } catch { /* ignore */ }
+  }, [])
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params: Record<string, any> = {
+        service, level, actor, action_type: actionType,
+        resource_type: resourceType, keyword, page, page_size: pageSize,
+      }
+      if (dateRange && dateRange[0]) params.start_at = dateRange[0].toISOString()
+      if (dateRange && dateRange[1]) params.end_at = dateRange[1].toISOString()
+      const res: any = await adminApi.queryAuditLogs(params)
+      setData({ total: res.data?.total || 0, items: res.data?.items || [] })
+    } catch (e: any) {
+      message.error(e?.response?.data?.message || '查询失败')
+    } finally {
+      setLoading(false)
+    }
+  }, [service, level, actor, actionType, resourceType, keyword, dateRange, page, pageSize])
+
+  useEffect(() => { fetchData() }, [fetchData])
+  useEffect(() => { fetchMeta() }, [fetchMeta])
+
+  const columns: ColumnsType<AuditItem> = [
+    { title: '时间', dataIndex: 'log_time', width: 160, render: v => <Text style={{ fontSize: 12 }}>{dayjs(v).format('YYYY-MM-DD HH:mm:ss')}</Text> },
+    { title: '操作者', dataIndex: 'actor', width: 110 },
+    {
+      title: '动作', key: 'action', width: 90,
+      render: (_, r) => <Tag color={ACTION_COLORS[r.action_type] || 'default'}>{ACTION_LABELS[r.action_type] || r.action_type}</Tag>,
+    },
+    {
+      title: '资源', key: 'resource', width: 160,
+      render: (_, r) => (
+        <Space size={4}>
+          <Tag color={RESOURCE_COLORS[r.resource_type] || 'default'}>{r.resource_type}</Tag>
+          <Text type="secondary" style={{ fontSize: 11 }}>#{r.resource_id}</Text>
+        </Space>
+      ),
+    },
+    { title: '消息', dataIndex: 'message', ellipsis: true },
+    {
+      title: '变更', key: 'diff', width: 80,
+      render: (_, r) => r.diff ? (
+        <Tooltip title={r.diff}>
+          <Button type="link" size="small" style={{ padding: 0 }}>查看</Button>
+        </Tooltip>
+      ) : '-',
+    },
+  ]
+
+  return (
+    <div>
+      <Card title={<Space><FileTextOutlined />审计日志</Space>} style={{ marginBottom: 16 }}>
+        <Space wrap>
+          <Select value={actor} onChange={setActor} placeholder="操作者" allowClear style={{ width: 120 }}>
+            {actors.map(v => <Option key={v} value={v}>{v}</Option>)}
+          </Select>
+          <Select value={actionType} onChange={setActionType} placeholder="动作" allowClear style={{ width: 110 }}>
+            {Object.keys(ACTION_LABELS).map(v => <Option key={v} value={v}>{ACTION_LABELS[v]}</Option>)}
+          </Select>
+          <Select value={resourceType} onChange={setResourceType} placeholder="资源类型" allowClear style={{ width: 140 }}>
+            {resourceTypes.map(v => <Option key={v} value={v}>{v}</Option>)}
+          </Select>
+          <Input.Search value={keyword} onChange={e => setKeyword(e.target.value)} onSearch={fetchData} placeholder="搜索消息/变更" allowClear style={{ width: 220 }} />
+          <RangePicker showTime value={dateRange} onChange={v => setDateRange(v as any)} />
+          <Button icon={<ReloadOutlined />} onClick={fetchData}>刷新</Button>
+        </Space>
+      </Card>
+      <Card>
+        <Table<AuditItem>
+          columns={columns} dataSource={data.items} rowKey="id" loading={loading}
+          size="small" scroll={{ x: 900 }}
+          pagination={{ current: page, total: data.total, pageSize, showSizeChanger: true, showTotal: t => `共 ${t} 条` }}
+          onChange={p => { setPage(p.current || 1); setPageSize(p.pageSize || 50) }}
+          {...tableStyle}
+        />
+      </Card>
+    </div>
+  )
+}
+
+export default SystemAudit


### PR DESCRIPTION
由 AI 助手整理（issue #63）。

## 背景
当前 SystemLog 仅记录服务运行日志，不记录"谁在什么时间改了什么配置"。

## 改动
- backend/model/models.go：SystemLog 扩展审计字段（actor/action_type/resource_type/resource_id/diff）
- backend/service/syslog/manager.go：AuditWrite/AuditParams、QueryParams 扩展过滤
- backend/api/handlers/portforward.go：接入 auditAudit（CREATE/UPDATE/DELETE）
- backend/api/handlers/admin.go：QueryLogs 接新过滤；GetAuditActors/GetAuditResourceTypes
- backend/api/router.go：/admin/audit/actors、/admin/audit/resource-types
- webpage/src/pages/SystemAudit.tsx：审计日志页（筛选+diff 弹窗）
- App.tsx / MainLayout.tsx / api/index.ts：注册路由菜单 API

验证：go build ./... 通过；tsc --noEmit 通过。