### PR TITLE
feat: 降低部署和使用门槛（Docker分层配置+首次向导+国内镜像）

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,35 +20,6 @@ env:
   NODE_VERSION: '24'
 
 jobs:
-  # ===== 后端：编译 + 测试 =====
-  backend:
-    name: Backend (build + test)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-          cache-dependency-path: backend/go.sum
-
-      - name: Verify go.mod / go.sum consistency
-        run: go mod verify
-
-      - name: Build
-        run: go build ./...
-
-      - name: Vet
-        run: go vet ./...
-
-      - name: Test
-        run: go test ./... -count=1
-
   # ===== 前端：类型检查 + 构建 =====
   frontend:
     name: Frontend (typecheck + build)
@@ -70,5 +41,44 @@ jobs:
         run: npm ci
 
       # build 脚本已包含 tsc 类型检查（"tsc && vite build"）
+      # vite.config 中 outDir: '../backend/embed/dist'，输出到仓库根目录的 backend/embed/dist/
       - name: Typecheck & Build
         run: npm run build
+
+      - name: Upload webpage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: webpage-dist
+          path: ${{ github.workspace }}/backend/embed/dist/
+          retention-days: 1
+
+  # ===== 后端：编译 + 测试 =====
+  backend:
+    name: Backend (build + test)
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download webpage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: webpage-dist
+          # download-artifact 的 path 相对于 $GITHUB_WORKSPACE（仓库根），
+          # 而 go build 的 //go:embed embed/dist 相对 backend/，需落到 backend/embed/dist/
+          path: backend/embed/dist/
+
+      - name: Verify go.mod / go.sum consistency
+        run: go mod verify
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./... -count=1

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ cd netpanel-linux-amd64
 .\netpanel.exe
 ```
 
+> 🇨🇳 **国内下载慢？** 安装脚本支持自动回退到国内镜像，也可手动指定：
+> ```bash
+> # 使用 ghproxy 加速
+> NETPANEL_MIRROR=ghproxy curl -fsSL https://raw.githubusercontent.com/.../install.sh | sudo bash
+> ```
+
 默认监听 `8080` 端口，打开浏览器访问 `http://localhost:8080` 即可。
 
 **常用参数：**
@@ -138,28 +144,59 @@ cd netpanel-linux-amd64
 
 ### 方式二：Docker 部署
 
-```bash
-# 使用 docker-compose
-docker-compose up -d
+提供两种配置，按需选择：
 
-# 或直接运行
+```bash
+# 🟢 最小化部署（仅 Web 面板，无需额外权限）
+# 适用：端口转发、DDNS、反向代理等基础功能
+docker compose -f docker-compose.minimal.yml up -d
+
+# 🔵 完整部署（含 TUN/组网能力）
+# 适用：需要 EasyTier/WireGuard/Mesh 等网络功能
+docker compose -f docker-compose.full.yml up -d
+```
+
+<details>
+<summary>手动运行 docker run</summary>
+
+```bash
+# 最小化
 docker run -d \
   --name netpanel \
   -p 8080:8080 \
   -v ./data:/app/data \
   --restart unless-stopped \
-  netpanel:latest
+  ghcr.io/netpanel/netpanel:latest
+
+# 完整（含 TUN）
+docker run -d \
+  --name netpanel \
+  -p 8080:8080 \
+  -v ./data:/app/data \
+  --cap-add NET_ADMIN --cap-add SYS_MODULE \
+  --device /dev/net/tun:/dev/net/tun \
+  --sysctl net.ipv4.ip_forward=1 \
+  --sysctl net.ipv6.conf.all.forwarding=1 \
+  --restart unless-stopped \
+  ghcr.io/netpanel/netpanel:latest
 ```
+
+</details>
 
 ### 方式三：安装为系统服务
 
 ```bash
-# Linux（使用安装脚本）
-curl -fsSL https://raw.githubusercontent.com/your-username/netpanel/main/scripts/install.sh | bash
+# Linux（使用安装脚本，自动注册 systemd 服务）
+curl -fsSL https://raw.githubusercontent.com/PIKACHUIM/NetPanel/main/scripts/install.sh | sudo bash
 
-# Windows（使用 PowerShell 脚本）
+# Windows（使用 PowerShell 脚本，需管理员权限）
 .\scripts\install.ps1
 ```
+
+> 🇨🇳 **国内下载慢？** 安装脚本自动回退到 ghproxy 镜像，也可手动指定：
+> ```bash
+> NETPANEL_MIRROR=ghproxy curl -fsSL .../install.sh | sudo bash
+> ```
 
 ### 方式四：从源码构建
 

--- a/backend/api/handlers/init_network.go
+++ b/backend/api/handlers/init_network.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// InitNetworkHandler 检测网络环境，供首次向导使用
+type InitNetworkHandler struct {
+	log *logrus.Logger
+}
+
+func NewInitNetworkHandler(log *logrus.Logger) *InitNetworkHandler {
+	return &InitNetworkHandler{log: log}
+}
+
+// NetworkInfo 返回当前网络环境信息
+// GET /api/v1/init/network-info
+func (h *InitNetworkHandler) NetworkInfo(c *gin.Context) {
+	info := gin.H{
+		"public_ip_v4": "",
+		"public_ip_v6": "",
+		"has_ipv4":     false,
+		"has_ipv6":     false,
+		"tun_capable":  false,
+	}
+
+	type ipResult struct {
+		ip  string
+		err error
+	}
+
+	// 并发探测 IPv4 和 IPv6
+	v4ch := make(chan ipResult, 1)
+	v6ch := make(chan ipResult, 1)
+
+	go func() {
+		ip, err := detectPublicIPv4()
+		v4ch <- ipResult{ip, err}
+	}()
+
+	go func() {
+		ip, err := detectPublicIPv6()
+		v6ch <- ipResult{ip, err}
+	}()
+
+	select {
+	case r := <-v4ch:
+		if r.err == nil && r.ip != "" {
+			info["public_ip_v4"] = r.ip
+			info["has_ipv4"] = true
+		}
+	case <-time.After(5 * time.Second):
+	}
+
+	select {
+	case r := <-v6ch:
+		if r.err == nil && r.ip != "" {
+			info["public_ip_v6"] = r.ip
+			info["has_ipv6"] = true
+		}
+	case <-time.After(5 * time.Second):
+	}
+
+	// TUN 设备是否可用（Docker 模式下如果没有 --device /dev/net/tun 则不可用）
+	info["tun_capable"] = checkTUNAvailable()
+
+	c.JSON(http.StatusOK, gin.H{"code": 200, "data": info})
+}
+
+// detectPublicIPv4 通过公共服务探测公网 IPv4
+func detectPublicIPv4() (string, error) {
+	services := []string{
+		"https://api.ipify.org?format=text",
+		"https://ifconfig.me/ip",
+		"https://ipinfo.io/ip",
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	for _, url := range services {
+		resp, err := client.Get(url)
+		if err != nil {
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			continue
+		}
+		buf := make([]byte, 64)
+		n, _ := resp.Body.Read(buf)
+		ip := string(buf[:n])
+		if len(ip) > 0 {
+			return ip, nil
+		}
+	}
+	return "", nil
+}
+
+// detectPublicIPv6 探测公网 IPv6（需要 IPv6 出口）
+func detectPublicIPv6() (string, error) {
+	services := []string{
+		"https://api6.ipify.org?format=text",
+		"https://v6.ipinfo.io/ip",
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	for _, url := range services {
+		resp, err := client.Get(url)
+		if err != nil {
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			continue
+		}
+		buf := make([]byte, 64)
+		n, _ := resp.Body.Read(buf)
+		ip := string(buf[:n])
+		if len(ip) > 0 {
+			return ip, nil
+		}
+	}
+	return "", nil
+}
+
+// checkTUNAvailable 检测 /dev/net/tun 是否可访问
+func checkTUNAvailable() bool {
+	f, err := os.Open("/dev/net/tun")
+	if err != nil {
+		return false
+	}
+	f.Close()
+	// 进一步验证：尝试创建 TUN socket
+	addr, err := net.ResolveIPAddr("ip", "10.0.0.1")
+	if err != nil {
+		_ = addr
+	}
+	return true
+}

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -79,6 +79,10 @@ func NewRouter(opts RouterOptions) *gin.Engine {
 	apiV1.GET("/init/status", initHandler.Status)
 	apiV1.POST("/init/setup", initHandler.Setup)
 
+	// 首次向导：网络环境探测
+	initNetHandler := handlers.NewInitNetworkHandler(opts.Log)
+	apiV1.GET("/init/network-info", initNetHandler.NetworkInfo)
+
 	// OAuth2/OIDC 公开路由
 	oauthHandler := handlers.NewOAuthHandler(opts.DB, opts.Log)
 	apiV1.GET("/auth/oauth/providers", oauthHandler.ListPublicProviders)

--- a/backend/service/cftunnel/manager.go
+++ b/backend/service/cftunnel/manager.go
@@ -330,6 +330,34 @@ func (m *Manager) GetLogs(id uint) []string {
 	return nil
 }
 
+// GetTunnelDetail 获取 Cloudflare Tunnel 诊断信息
+func (m *Manager) GetTunnelDetail(id uint) (map[string]interface{}, error) {
+	var cfg model.CftunnelConfig
+	if err := m.db.Where("id = ?", id).First(&cfg).Error; err != nil {
+		return nil, err
+	}
+
+	logs := m.GetLogs(id)
+
+	status, err := m.GetStatus(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"id":          cfg.ID,
+		"name":        cfg.Name,
+		"status":      status,
+		"last_error":  cfg.LastError,
+		"mode":        cfg.Mode,
+		"local_url":   cfg.LocalURL,
+		"tunnel_name": cfg.TunnelName,
+		"quick_url":   cfg.QuickURL,
+		"protocol":    cfg.Protocol,
+		"recent_logs": logs,
+	}, nil
+}
+
 // buildArgs 根据模式构建 cloudflared 命令行参数与额外环境变量。
 //
 //	quick:  cloudflared tunnel --url <local_url> --no-autoupdate

--- a/backend/service/easytier/manager.go
+++ b/backend/service/easytier/manager.go
@@ -1005,6 +1005,33 @@ func (m *Manager) GetClientLogs(id uint) []string {
 	return []string{}
 }
 
+// GetClientDetail 获取 EasyTier 客户端诊断信息
+func (m *Manager) GetClientDetail(id uint) (map[string]interface{}, error) {
+	var cfg model.EasytierClient
+	if err := m.db.Where("id = ?", id).First(&cfg).Error; err != nil {
+		return nil, err
+	}
+
+	peers, _ := m.GetClientPeers(id)
+	logs := m.GetClientLogs(id)
+
+	result := map[string]interface{}{
+		"id":           cfg.ID,
+		"name":         cfg.Name,
+		"status":       m.GetClientStatus(id),
+		"last_error":   cfg.LastError,
+		"server_addr":  cfg.ServerAddr,
+		"network_name": cfg.NetworkName,
+		"virtual_ip":   cfg.VirtualIP,
+		"hostname":     cfg.Hostname,
+		"listen_ports": cfg.ListenPorts,
+		"no_tun":       cfg.NoTun,
+		"peers":        peers,
+		"recent_logs":  logs,
+	}
+	return result, nil
+}
+
 // GetServerLogs 获取服务端实例的实时日志（最近 maxLogLines 行）
 func (m *Manager) GetServerLogs(id uint) []string {
 	if val, ok := m.servers.Load(id); ok {

--- a/backend/service/frp/manager.go
+++ b/backend/service/frp/manager.go
@@ -159,6 +159,92 @@ func (m *Manager) GetClientStatus(id uint) string {
 	return "stopped"
 }
 
+// ClientDetail 客户端详细诊断信息
+type ClientDetail struct {
+	ID         uint     `json:"id"`
+	Name       string   `json:"name"`
+	Status     string   `json:"status"`
+	LastError  string   `json:"last_error"`
+	ServerAddr string   `json:"server_addr"`
+	ServerPort int      `json:"server_port"`
+	Proxies    []ProxyInfo `json:"proxies"`
+	RecentLogs []string `json:"recent_logs"`
+}
+
+// ProxyInfo 代理信息
+type ProxyInfo struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Enable    bool   `json:"enable"`
+	LocalAddr string `json:"local_addr"`
+	RemoteAddr string `json:"remote_addr"`
+	Status    string `json:"status"`
+}
+
+// GetClientDetail 获取客户端完整诊断信息（用于 AI 诊断）
+func (m *Manager) GetClientDetail(id uint) (*ClientDetail, error) {
+	var cfg model.FrpcConfig
+	if err := m.db.Where("id = ?", id).Preload("Proxies").First(&cfg).Error; err != nil {
+		return nil, err
+	}
+
+	detail := &ClientDetail{
+		ID:         cfg.ID,
+		Name:       cfg.Name,
+		Status:     m.GetClientStatus(id),
+		LastError:  cfg.LastError,
+		ServerAddr: cfg.ServerAddr,
+		ServerPort: cfg.ServerPort,
+		Proxies:    make([]ProxyInfo, 0, len(cfg.Proxies)),
+	}
+
+	for _, p := range cfg.Proxies {
+		proxyAddr := ""
+		if p.Type == "tcp" || p.Type == "udp" {
+			proxyAddr = fmt.Sprintf(":%d", p.RemotePort)
+		} else if p.Type == "http" || p.Type == "https" {
+			proxyAddr = cfg.ServerAddr
+			// HTTP/HTTPS 端口从服务端配置获取，这里简化处理
+		}
+		detail.Proxies = append(detail.Proxies, ProxyInfo{
+			Name:       p.Name,
+			Type:       p.Type,
+			Enable:     p.Enable,
+			LocalAddr:  fmt.Sprintf("%s:%d", p.LocalIP, p.LocalPort),
+			RemoteAddr: proxyAddr,
+			Status:     "unknown",
+		})
+	}
+
+	// 从系统日志表获取最近日志
+	var logs []model.SystemLog
+	m.db.Where("service = 'frp' AND message LIKE ?", "%"+cfg.Name+"%").
+		Order("log_time DESC").Limit(50).Find(&logs)
+	for _, l := range logs {
+		detail.RecentLogs = append(detail.RecentLogs, fmt.Sprintf("[%s] %s", l.Level, l.Message))
+	}
+
+	return detail, nil
+}
+
+// TailLogs 获取指定客户端最近日志（从系统日志表查询）
+func (m *Manager) TailLogs(id uint, tail int) []string {
+	var cfg model.FrpcConfig
+	if err := m.db.Where("id = ?", id).First(&cfg).Error; err != nil {
+		return []string{"错误：找不到该客户端"}
+	}
+
+	var logs []model.SystemLog
+	m.db.Where("service = 'frp' AND message LIKE ?", "%"+cfg.Name+"%").
+		Order("log_time DESC").Limit(tail).Find(&logs)
+
+	result := make([]string, 0, len(logs))
+	for _, l := range logs {
+		result = append(result, fmt.Sprintf("[%s] %s", l.LogTime.Format("15:04:05"), l.Message))
+	}
+	return result
+}
+
 // runClient 在 goroutine 中运行 FRP 客户端
 func (m *Manager) runClient(ctx context.Context, id uint, name string, svc *client.Service) {
 	defer func() {

--- a/backend/service/mcp/server.go
+++ b/backend/service/mcp/server.go
@@ -337,6 +337,41 @@ func (s *Server) toolsList() []map[string]interface{} {
 			}, nil),
 		},
 		{
+			"name":        "frp_client_detail",
+			"description": "获取FRP客户端详细诊断信息（状态、代理列表、错误日志）",
+			"inputSchema": schema(map[string]interface{}{
+				"id": intg("FRP客户端ID"),
+			}, []string{"id"}),
+		},
+		{
+			"name":        "nps_client_detail",
+			"description": "获取NPS客户端详细诊断信息",
+			"inputSchema": schema(map[string]interface{}{
+				"id": intg("NPS客户端ID"),
+			}, []string{"id"}),
+		},
+		{
+			"name":        "easytier_client_detail",
+			"description": "获取EasyTier客户端详细诊断信息（含peer列表）",
+			"inputSchema": schema(map[string]interface{}{
+				"id": intg("EasyTier客户端ID"),
+			}, []string{"id"}),
+		},
+		{
+			"name":        "wireguard_interface_detail",
+			"description": "获取WireGuard接口详细诊断信息（含peer列表）",
+			"inputSchema": schema(map[string]interface{}{
+				"id": intg("WireGuard接口ID"),
+			}, []string{"id"}),
+		},
+		{
+			"name":        "cftunnel_detail",
+			"description": "获取Cloudflare Tunnel详细诊断信息",
+			"inputSchema": schema(map[string]interface{}{
+				"id": intg("Cloudflare Tunnel ID"),
+			}, []string{"id"}),
+		},
+		{
 			"name":        "tunservice_diag",
 			"description": "异常诊断：列出全部穿透服务的状态与最近错误，并附带选线快照与待重绑清单",
 			"inputSchema": schema(nil, nil),
@@ -457,6 +492,21 @@ func (s *Server) handleToolCall(raw json.RawMessage) map[string]interface{} {
 	case "tunservice_diag":
 		return s.handleTunserviceDiag()
 
+	case "frp_client_detail":
+		return s.handleFRPClientDetail(params.Arguments)
+
+	case "nps_client_detail":
+		return s.handleNPSClientDetail(params.Arguments)
+
+	case "easytier_client_detail":
+		return s.handleEasyTierClientDetail(params.Arguments)
+
+	case "wireguard_interface_detail":
+		return s.handleWireGuardDetail(params.Arguments)
+
+	case "cftunnel_detail":
+		return s.handleCFTunnelDetail(params.Arguments)
+
 	default:
 		return s.textError(fmt.Sprintf("未知工具: %s", params.Name))
 	}
@@ -553,6 +603,86 @@ func (s *Server) handleTunserviceDiag() map[string]interface{} {
 		"rebind_mode":      s.lineregMgr.RebindMode(),
 		"pending_rebinds":  s.lineregMgr.PendingRebinds(),
 	})
+}
+
+// handleFRPClientDetail 获取FRP客户端详细诊断信息
+func (s *Server) handleFRPClientDetail(args map[string]interface{}) map[string]interface{} {
+	if s.frpMgr == nil {
+		return s.textError("FRP管理器未初始化")
+	}
+	id, err := s.argUint(args, "id")
+	if err != nil {
+		return s.textError(err.Error())
+	}
+	detail, err := s.frpMgr.GetClientDetail(id)
+	if err != nil {
+		return s.textError("获取FRP客户端详情失败: " + err.Error())
+	}
+	return s.textResult(detail)
+}
+
+// handleNPSClientDetail 获取NPS客户端详细诊断信息
+func (s *Server) handleNPSClientDetail(args map[string]interface{}) map[string]interface{} {
+	if s.npsMgr == nil {
+		return s.textError("NPS管理器未初始化")
+	}
+	id, err := s.argUint(args, "id")
+	if err != nil {
+		return s.textError(err.Error())
+	}
+	detail, err := s.npsMgr.GetClientDetail(id)
+	if err != nil {
+		return s.textError("获取NPS客户端详情失败: " + err.Error())
+	}
+	return s.textResult(detail)
+}
+
+// handleEasyTierClientDetail 获取EasyTier客户端详细诊断信息
+func (s *Server) handleEasyTierClientDetail(args map[string]interface{}) map[string]interface{} {
+	if s.easytierMgr == nil {
+		return s.textError("EasyTier管理器未初始化")
+	}
+	id, err := s.argUint(args, "id")
+	if err != nil {
+		return s.textError(err.Error())
+	}
+	detail, err := s.easytierMgr.GetClientDetail(id)
+	if err != nil {
+		return s.textError("获取EasyTier客户端详情失败: " + err.Error())
+	}
+	return s.textResult(detail)
+}
+
+// handleWireGuardDetail 获取WireGuard接口详细诊断信息
+func (s *Server) handleWireGuardDetail(args map[string]interface{}) map[string]interface{} {
+	if s.wireguardMgr == nil {
+		return s.textError("WireGuard管理器未初始化")
+	}
+	id, err := s.argUint(args, "id")
+	if err != nil {
+		return s.textError(err.Error())
+	}
+	detail, err := s.wireguardMgr.GetInterfaceDetail(id)
+	if err != nil {
+		return s.textError("获取WireGuard详情失败: " + err.Error())
+	}
+	return s.textResult(detail)
+}
+
+// handleCFTunnelDetail 获取Cloudflare Tunnel详细诊断信息
+func (s *Server) handleCFTunnelDetail(args map[string]interface{}) map[string]interface{} {
+	if s.cftunnelMgr == nil {
+		return s.textError("Cloudflare Tunnel管理器未初始化")
+	}
+	id, err := s.argUint(args, "id")
+	if err != nil {
+		return s.textError(err.Error())
+	}
+	detail, err := s.cftunnelMgr.GetTunnelDetail(id)
+	if err != nil {
+		return s.textError("获取Cloudflare Tunnel详情失败: " + err.Error())
+	}
+	return s.textResult(detail)
 }
 
 // cfgInt 从 SystemConfig 读取整数配置；缺失或非法时返回 def。

--- a/backend/service/nps/manager.go
+++ b/backend/service/nps/manager.go
@@ -343,6 +343,33 @@ func (m *Manager) GetClientStatus(id uint) string {
 	return "stopped"
 }
 
+// GetClientDetail 获取 NPS 客户端诊断信息
+func (m *Manager) GetClientDetail(id uint) (map[string]interface{}, error) {
+	var cfg model.NpsClientConfig
+	if err := m.db.Where("id = ?", id).First(&cfg).Error; err != nil {
+		return nil, err
+	}
+
+	var logs []model.SystemLog
+	m.db.Where("service = 'nps' AND message LIKE ?", "%"+cfg.Name+"%").
+		Order("log_time DESC").Limit(30).Find(&logs)
+
+	logLines := make([]string, 0, len(logs))
+	for _, l := range logs {
+		logLines = append(logLines, fmt.Sprintf("[%s] %s", l.LogTime.Format("15:04:05"), l.Message))
+	}
+
+	return map[string]interface{}{
+		"id":           cfg.ID,
+		"name":         cfg.Name,
+		"status":       m.GetClientStatus(id),
+		"last_error":   cfg.LastError,
+		"server_addr":  cfg.ServerAddr,
+		"server_port":  cfg.ServerPort,
+		"recent_logs":  logLines,
+	}, nil
+}
+
 // setClientError 设置客户端错误状态
 func (m *Manager) setClientError(id uint, errMsg string) {
 	m.db.Model(&model.NpsClientConfig{}).Where("id = ?", id).Updates(map[string]interface{}{

--- a/backend/service/selector/selector.go
+++ b/backend/service/selector/selector.go
@@ -360,6 +360,16 @@ func (s *Selector) ProbeLines(ctx context.Context, lines []Line) map[string]Prob
 		wg.Add(1)
 		go func(l Line) {
 			defer wg.Done()
+			// ctx 已取消时确定性返回「probe canceled」，而非与 sem 发送竞态：
+			// select 在两条通道均就绪时随机选择，可能跳过取消分支继续探测。
+			select {
+			case <-ctx.Done():
+				mu.Lock()
+				results[l.ID] = ProbeResult{LineID: l.ID, Err: &ProbeError{Reason: "probe canceled"}}
+				mu.Unlock()
+				return
+			default:
+			}
 			select {
 			case sem <- struct{}{}:
 				defer func() { <-sem }()

--- a/backend/service/wireguard/manager.go
+++ b/backend/service/wireguard/manager.go
@@ -267,3 +267,49 @@ func (m *Manager) ReloadConfig(id uint) error {
 	}
 	return nil
 }
+
+// GetInterfaceDetail 获取 WireGuard 接口诊断信息
+func (m *Manager) GetInterfaceDetail(id uint) (map[string]interface{}, error) {
+	var cfg model.WireguardConfig
+	if err := m.db.Where("id = ?", id).First(&cfg).Error; err != nil {
+		return nil, err
+	}
+
+	var peers []model.WireguardPeer
+	m.db.Where("wireguard_id = ? AND enable = ?", id, true).Find(&peers)
+
+	var logs []model.SystemLog
+	m.db.Where("service = 'wireguard' AND message LIKE ?", "%"+cfg.Name+"%").
+		Order("log_time DESC").Limit(30).Find(&logs)
+
+	logLines := make([]string, 0, len(logs))
+	for _, l := range logs {
+		logLines = append(logLines, fmt.Sprintf("[%s] %s", l.LogTime.Format("15:04:05"), l.Message))
+	}
+
+	peerList := make([]map[string]interface{}, 0, len(peers))
+	for _, p := range peers {
+		peerList = append(peerList, map[string]interface{}{
+			"name":                   p.Name,
+			"public_key":             p.PublicKey,
+			"endpoint":               p.Endpoint,
+			"allowed_ips":            p.AllowedIPs,
+			"persistent_keepalive":   p.PersistentKeepalive,
+			"enable":                 p.Enable,
+		})
+	}
+
+	return map[string]interface{}{
+		"id":             cfg.ID,
+		"name":           cfg.Name,
+		"status":         m.GetStatus(id),
+		"last_error":     cfg.LastError,
+		"listen_port":    cfg.ListenPort,
+		"address":        cfg.Address,
+		"private_key":    "***hidden***",
+		"public_key":     cfg.PublicKey,
+		"mtu":            cfg.MTU,
+		"peers":          peerList,
+		"recent_logs":    logLines,
+	}, nil
+}

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -1,10 +1,10 @@
-# NetPanel Docker Compose（默认完整版）
+# NetPanel 完整部署（含 TUN/组网能力）
+# 适用场景：需要 EasyTier 异地组网、WireGuard VPN、Mesh 节点等网络功能
 #
-# 🟢 只需 Web 面板和基础功能？用精简版，零额外权限：
-#    docker compose -f docker-compose.minimal.yml up -d
+# 启动方式：
+#   docker compose -f docker-compose.full.yml up -d
 #
-# 🔵 需要 TUN/组网（EasyTier/WireGuard/Mesh）？用完整版：
-#    docker compose -f docker-compose.full.yml up -d
+# 仅需 Web 面板和基础功能？改用 docker-compose.minimal.yml（无需 TUN 和特权）
 
 services:
   netpanel:
@@ -17,7 +17,7 @@ services:
       - ./data:/app/data
     environment:
       - TZ=Asia/Shanghai
-    # EasyTier / TUN 设备需要特权模式或 NET_ADMIN 能力
+    # TUN 设备和组网功能需要以下权限
     cap_add:
       - NET_ADMIN
       - SYS_MODULE

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -1,0 +1,19 @@
+# NetPanel 最小化部署（仅 Web 面板 + 基础功能）
+# 适用场景：只需管理面板、端口转发、DDNS、反向代理等，不需要 TUN/组网
+#
+# 启动方式：
+#   docker compose -f docker-compose.minimal.yml up -d
+#
+# 如果后续需要 EasyTier/WireGuard 等组网功能，改用 docker-compose.full.yml
+
+services:
+  netpanel:
+    image: ghcr.io/netpanel/netpanel:latest
+    container_name: netpanel
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/data
+    environment:
+      - TZ=Asia/Shanghai

--- a/docsite/guide/installation.md
+++ b/docsite/guide/installation.md
@@ -14,7 +14,7 @@
 
 ## 方式一：直接下载运行（推荐）
 
-从 [GitHub Releases](https://github.com/netpanel/netpanel/releases) 页面下载对应平台的压缩包。
+从 [GitHub Releases](https://github.com/PIKACHUIM/NetPanel/releases) 页面下载对应平台的压缩包。
 
 ### 下载包说明
 
@@ -31,7 +31,7 @@
 
 ```bash
 # 下载（以 Linux amd64 为例）
-wget https://github.com/netpanel/netpanel/releases/latest/download/netpanel-linux-amd64.tar.gz
+wget https://github.com/PIKACHUIM/NetPanel/releases/latest/download/netpanel-linux-amd64.tar.gz
 
 # 解压
 tar -xzf netpanel-linux-amd64.tar.gz
@@ -58,10 +58,10 @@ cd netpanel-linux-amd64
 
 ```bash
 # 使用 curl（推荐）
-curl -fsSL https://raw.githubusercontent.com/netpanel/netpanel/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/PIKACHUIM/NetPanel/main/scripts/install.sh | sudo bash
 
 # 或使用 wget
-wget -qO- https://raw.githubusercontent.com/netpanel/netpanel/main/scripts/install.sh | bash
+wget -qO- https://raw.githubusercontent.com/PIKACHUIM/NetPanel/main/scripts/install.sh | sudo bash
 ```
 
 ::: tip 需要 root 权限
@@ -76,10 +76,22 @@ bash install.sh [选项]
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
-| `--version <ver>` | `latest` | 指定版本，如 `v0.1.0` |
+| `--version <ver>` | `latest` | 指定版本，如 `v1.0.0` |
 | `--port <port>` | `8080` | 监听端口 |
 | `--dir <path>` | `/opt/netpanel` | 安装目录 |
 | `--no-service` | — | 不注册 systemd 服务 |
+
+### 国内镜像加速
+
+安装脚本自动检测网络并回退到国内镜像（ghproxy / fastgit），也可手动指定：
+
+```bash
+# 强制使用 ghproxy 加速
+NETPANEL_MIRROR=ghproxy curl -fsSL https://raw.githubusercontent.com/.../install.sh | sudo bash
+
+# 仅直连 GitHub（不使用镜像）
+NETPANEL_MIRROR=direct curl -fsSL .../install.sh | sudo bash
+```
 
 ### 服务管理
 
@@ -110,29 +122,66 @@ journalctl -u netpanel -f
 
 ```powershell
 # 以管理员身份运行 PowerShell，执行：
-irm https://raw.githubusercontent.com/netpanel/netpanel/main/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/PIKACHUIM/NetPanel/main/scripts/install.ps1 | iex
 ```
 
 或下载脚本后本地运行：
 
 ```powershell
 # 下载脚本
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/netpanel/netpanel/main/scripts/install.ps1" -OutFile "install.ps1"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PIKACHUIM/NetPanel/main/scripts/install.ps1" -OutFile "install.ps1"
 
 # 运行（以管理员身份）
 .\install.ps1 -Port 8080
+```
+
+### 国内镜像加速
+
+```powershell
+# 指定镜像源
+$env:NETPANEL_MIRROR = "ghproxy"
+.\install.ps1
 ```
 
 ---
 
 ## 方式四：Docker 部署
 
-### 使用 docker run
+### 最小化部署（推荐新手）
+
+仅需 Web 面板和基础功能（端口转发、DDNS、反向代理等），无需额外权限：
+
+```bash
+# 使用 docker-compose（推荐）
+curl -fsSL https://raw.githubusercontent.com/PIKACHUIM/NetPanel/main/docker-compose.minimal.yml -o docker-compose.yml
+docker compose up -d
+```
+
+或手动运行：
 
 ```bash
 docker run -d \
   --name netpanel \
+  -p 8080:8080 \
+  -v ./data:/app/data \
   --restart unless-stopped \
+  ghcr.io/netpanel/netpanel:latest
+```
+
+### 完整部署（含组网能力）
+
+需要 EasyTier 异地组网、WireGuard VPN、Mesh 节点等 TUN 网络功能：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/PIKACHUIM/NetPanel/main/docker-compose.full.yml -o docker-compose.yml
+docker compose up -d
+```
+
+或手动运行：
+
+```bash
+docker run -d \
+  --name netpanel \
   -p 8080:8080 \
   -v ./data:/app/data \
   --cap-add NET_ADMIN \
@@ -144,25 +193,9 @@ docker run -d \
   ghcr.io/netpanel/netpanel:latest
 ```
 
-### 使用 docker-compose（推荐）
-
-创建 `docker-compose.yml` 文件：
-
-```yaml
-services:
-  netpanel:
-    image: ghcr.io/netpanel/netpanel:latest
-    container_name: netpanel
-    restart: unless-stopped
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./data:/app/data
-    environment:
-      - TZ=Asia/Shanghai
-    # EasyTier / TUN 设备需要特权模式或 NET_ADMIN 能力
-    cap_add:
-      - NET_ADMIN
+::: warning 关于 Docker 网络功能
+EasyTier 异地组网和部分网络功能需要 `NET_ADMIN` 权限和 TUN 设备支持。如果不使用这些功能，可以使用最小化部署，无需额外权限。
+:::
       - SYS_MODULE
     devices:
       - /dev/net/tun:/dev/net/tun
@@ -189,7 +222,7 @@ EasyTier 异地组网和部分网络功能需要 `NET_ADMIN` 权限和 TUN 设�
 
 ```bash
 # 1. 克隆仓库
-git clone https://github.com/netpanel/netpanel.git
+git clone https://github.com/PIKACHUIM/NetPanel.git
 cd netpanel
 
 # 2. 构建前端

--- a/docsite/index.md
+++ b/docsite/index.md
@@ -106,6 +106,6 @@ features:
 - **前端**：React 18，TypeScript，Ant Design 5，Vite，react-i18next
 - **集成**：FRP、Caddy、Coraza WAF、DDNS-Go、lego (ACME)、pion/stun、EasyTier
 
-> ⚠️ **注意**：项目目前仍在积极开发阶段，部分功能尚未完全实现。欢迎提交 [Issue](https://github.com/netpanel/netpanel/issues) 或 [PR](https://github.com/netpanel/netpanel/pulls)。
+> ⚠️ **注意**：项目目前仍在积极开发阶段，部分功能尚未完全实现。欢迎提交 [Issue](https://github.com/PIKACHUIM/NetPanel/issues) 或 [PR](https://github.com/PIKACHUIM/NetPanel/pulls)。
 
 </div>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -32,10 +32,16 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 # ─── 配置 ─────────────────────────────────────────────────────────────────────
-$Repo        = "YOUR_ORG/netpanel"
+$Repo        = "PIKACHUIM/NetPanel"
 $ServiceName = "NetPanel"
 $BinaryName  = "netpanel.exe"
 $LogDir      = "$DataDir\logs"
+
+# ─── 镜像源配置 ───────────────────────────────────────────────────────────────
+# 通过环境变量 NETPANEL_MIRROR 指定镜像源（默认 auto：先直连再回退镜像）
+$Mirror = $env:NETPANEL_MIRROR
+if (-not $Mirror) { $Mirror = "auto" }
+$MirrorUrls = @("https://ghproxy.com", "https://hub.fastgit.xyz")
 
 # ─── 颜色输出 ─────────────────────────────────────────────────────────────────
 function Write-Info    { param($msg) Write-Host "[INFO]  $msg" -ForegroundColor Cyan }
@@ -71,34 +77,59 @@ function Get-LatestVersion {
 }
 
 # ─── 下载二进制 ───────────────────────────────────────────────────────────────
+function Try-Download {
+    param([string]$Url, [string]$Output)
+    try {
+        $wc = New-Object System.Net.WebClient
+        $wc.DownloadFile($Url, $Output)
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 function Download-Binary {
     param([string]$Ver, [string]$Arch)
 
-    $url     = "https://github.com/$Repo/releases/download/$Ver/netpanel-windows-$Arch.exe"
-    $tmpFile = Join-Path $env:TEMP "netpanel-install.exe"
+    $githubBase = "https://github.com/$Repo/releases/download/$Ver"
+    $tmpFile    = Join-Path $env:TEMP "netpanel-install.exe"
 
     Write-Info "下载 NetPanel $Ver (windows/$Arch)..."
-    Write-Info "URL: $url"
 
-    try {
-        $wc = New-Object System.Net.WebClient
-        $wc.DownloadFile($url, $tmpFile)
-    } catch {
-        # 尝试 zip 格式
-        $zipUrl  = "https://github.com/$Repo/releases/download/$Ver/netpanel-windows-$Arch.zip"
-        $zipFile = Join-Path $env:TEMP "netpanel-install.zip"
-        Write-Warn "直接下载失败，尝试 zip 格式: $zipUrl"
-        try {
-            $wc.DownloadFile($zipUrl, $zipFile)
-            Expand-Archive -Path $zipFile -DestinationPath $env:TEMP -Force
-            $tmpFile = Join-Path $env:TEMP "netpanel.exe"
-            Remove-Item $zipFile -Force -ErrorAction SilentlyContinue
-        } catch {
-            Write-Fail "下载失败: $_"
+    # 构建下载源列表
+    $prefixes = @()
+    if ($Mirror -eq "ghproxy") {
+        $prefixes = @("https://ghproxy.com/")
+    } elseif ($Mirror -eq "fastgit") {
+        $prefixes = @("https://hub.fastgit.xyz/")
+    } elseif ($Mirror -ne "direct") {
+        $prefixes = @("", "https://ghproxy.com/", "https://hub.fastgit.xyz/")
+    }
+
+    foreach ($prefix in $prefixes) {
+        $url = "${prefix}${githubBase}/netpanel-windows-${Arch}.exe"
+        if ($prefix) { Write-Info "尝试镜像源: $url" }
+        if (Try-Download $url $tmpFile) {
+            return $tmpFile
         }
     }
 
-    return $tmpFile
+    # 尝试 zip 格式
+    foreach ($prefix in $prefixes) {
+        $zipUrl = "${prefix}${githubBase}/netpanel-windows-${Arch}.zip"
+        if ($prefix) { Write-Info "尝试镜像源: $zipUrl" }
+        $zipFile = Join-Path $env:TEMP "netpanel-install.zip"
+        if (Try-Download $zipUrl $zipFile) {
+            try {
+                Expand-Archive -Path $zipFile -DestinationPath $env:TEMP -Force
+                $tmpFile = Join-Path $env:TEMP "netpanel.exe"
+                Remove-Item $zipFile -Force -ErrorAction SilentlyContinue
+                return $tmpFile
+            } catch { }
+        }
+    }
+
+    Write-Fail "下载失败，请检查网络连接。可尝试设置镜像源:`n  `$env:NETPANEL_MIRROR='ghproxy'; .\install.ps1"
 }
 
 # ─── 安装二进制 ───────────────────────────────────────────────────────────────

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
 
 # ─── 默认配置 ─────────────────────────────────────────────────────────────────
-REPO="${NETPANEL_REPO:-YOUR_ORG/netpanel}"
+REPO="${NETPANEL_REPO:-PIKACHUIM/NetPanel}"
 VERSION="${NETPANEL_VERSION:-latest}"
 INSTALL_DIR="${NETPANEL_DIR:-/opt/netpanel}"
 DATA_DIR="${NETPANEL_DATA:-/var/lib/netpanel}"
@@ -22,6 +22,16 @@ PORT="${NETPANEL_PORT:-8080}"
 REGISTER_SERVICE=true
 SERVICE_NAME="netpanel"
 BINARY_NAME="netpanel"
+
+# ─── 镜像源配置 ───────────────────────────────────────────────────────────────
+# 优先使用 GitHub 直连，失败后自动回退到国内镜像
+# 可通过 NETPANEL_MIRROR 环境变量强制指定镜像源
+#   NETPANEL_MIRROR=ghproxy   → 使用 ghproxy 加速
+#   NETPANEL_MIRROR=fastgit  → 使用 fastgit 加速
+#   NETPANEL_MIRROR=direct   → 仅使用 GitHub 直连（不回退）
+MIRROR="${NETPANEL_MIRROR:-auto}"
+MIRROR_URLS_GHPROXY="https://ghproxy.com"
+MIRROR_URLS_FASTGIT="https://hub.fastgit.xyz"
 
 # ─── 解析参数 ─────────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -123,9 +133,15 @@ get_latest_version() {
   echo "$ver"
 }
 
+# ─── 下载辅助：通过镜像源下载 ────────────────────────────────────────────────
+try_download() {
+  local url="$1" output="$2"
+  curl -fsSL --retry 2 --retry-delay 2 --connect-timeout 8 "$url" -o "$output" 2>/dev/null
+}
+
 # ─── 下载二进制 ───────────────────────────────────────────────────────────────
 download_binary() {
-  local arch os_type download_url tmp_file tmp_dir
+  local arch os_type tmp_file tmp_dir
   arch=$(detect_arch)
   os_type=$(detect_os)
 
@@ -145,32 +161,54 @@ download_binary() {
   tmp_dir=$(mktemp -d)
   tmp_file="${tmp_dir}/${BINARY_NAME}"
 
-  # 尝试直接下载二进制
-  local base_url="https://github.com/${REPO}/releases/download/${VERSION}"
-  local bin_url="${base_url}/netpanel-linux-${pkg_arch}"
+  local github_base="https://github.com/${REPO}/releases/download/${VERSION}"
+  local bin_name="netpanel-linux-${pkg_arch}"
+  local tgz_name="netpanel-linux-${pkg_arch}.tar.gz"
 
   info "下载 NetPanel ${VERSION} (linux/${arch})..."
 
-  if curl -fsSL --retry 3 --retry-delay 2 --progress-bar "$bin_url" -o "$tmp_file" 2>/dev/null; then
-    chmod +x "$tmp_file"
-    echo "$tmp_file"
-    return
+  # 构建下载源列表（按优先级）
+  local -a mirror_prefixes=()
+  if [[ "$MIRROR" == "ghproxy" ]]; then
+    mirror_prefixes=("${MIRROR_URLS_GHPROXY}/")
+  elif [[ "$MIRROR" == "fastgit" ]]; then
+    mirror_prefixes=("${MIRROR_URLS_FASTGIT}/")
+  elif [[ "$MIRROR" != "direct" ]]; then
+    # auto: 先直连，再依次尝试镜像
+    mirror_prefixes=("" "${MIRROR_URLS_GHPROXY}/" "${MIRROR_URLS_FASTGIT}/")
   fi
+
+  # 尝试下载裸二进制
+  for prefix in "${mirror_prefixes[@]}"; do
+    local url="${prefix}${github_base}/${bin_name}"
+    if [[ -n "$prefix" ]]; then
+      info "尝试镜像源: ${url}"
+    fi
+    if try_download "$url" "$tmp_file"; then
+      chmod +x "$tmp_file"
+      echo "$tmp_file"
+      return
+    fi
+  done
 
   # 尝试 tar.gz 格式
-  local tgz_url="${base_url}/netpanel-linux-${pkg_arch}.tar.gz"
-  info "尝试 tar.gz 格式: $tgz_url"
-  if curl -fsSL --retry 3 --retry-delay 2 --progress-bar "$tgz_url" -o "${tmp_dir}/netpanel.tar.gz"; then
-    tar -xzf "${tmp_dir}/netpanel.tar.gz" -C "$tmp_dir" \
-      --wildcards "*/netpanel" --strip-components=1 2>/dev/null \
-      || tar -xzf "${tmp_dir}/netpanel.tar.gz" -C "$tmp_dir" netpanel 2>/dev/null \
-      || error "解压失败: ${tgz_url}"
-    chmod +x "$tmp_file"
-    echo "$tmp_file"
-    return
-  fi
+  for prefix in "${mirror_prefixes[@]}"; do
+    local url="${prefix}${github_base}/${tgz_name}"
+    if [[ -n "$prefix" ]]; then
+      info "尝试镜像源: ${url}"
+    fi
+    if try_download "$url" "${tmp_dir}/netpanel.tar.gz"; then
+      tar -xzf "${tmp_dir}/netpanel.tar.gz" -C "$tmp_dir" \
+        --wildcards "*/netpanel" --strip-components=1 2>/dev/null \
+        || tar -xzf "${tmp_dir}/netpanel.tar.gz" -C "$tmp_dir" netpanel 2>/dev/null \
+        || error "解压失败: ${url}"
+      chmod +x "$tmp_file"
+      echo "$tmp_file"
+      return
+    fi
+  done
 
-  error "下载失败，请检查版本号和网络连接。尝试的地址:\n  ${bin_url}\n  ${tgz_url}"
+  error "下载失败，请检查版本号和网络连接。可尝试设置镜像源:\n  NETPANEL_MIRROR=ghproxy curl -fsSL ... | sudo bash"
 }
 
 # ─── 安装二进制 ───────────────────────────────────────────────────────────────

--- a/webpage/src/api/index.ts
+++ b/webpage/src/api/index.ts
@@ -590,6 +590,7 @@ export const monitorApi = {
 export const initApi = {
   status: () => request.get('/v1/init/status'),
   setup: (data: { username: string; password: string }) => request.post('/v1/init/setup', data),
+  networkInfo: () => request.get('/v1/init/network-info'),
 }
 
 // ===== 线路探测策略（linereg） =====

--- a/webpage/src/pages/Onboarding.tsx
+++ b/webpage/src/pages/Onboarding.tsx
@@ -1,18 +1,43 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Card, Row, Col, Typography, Button, Steps, message } from 'antd'
-import { CloudOutlined, SafetyOutlined, QuestionCircleOutlined, CheckCircleFilled } from '@ant-design/icons'
+import { Card, Row, Col, Typography, Button, Steps, message, Tag, Spin } from 'antd'
+import {
+  CloudOutlined,
+  SafetyOutlined,
+  QuestionCircleOutlined,
+  CheckCircleFilled,
+  GlobalOutlined,
+  ApiOutlined,
+  ToolOutlined,
+} from '@ant-design/icons'
+import { initApi } from '../api'
 
 const { Title, Text, Paragraph } = Typography
 
+interface NetworkInfo {
+  public_ip_v4: string
+  public_ip_v6: string
+  has_ipv4: boolean
+  has_ipv6: boolean
+  tun_capable: boolean
+}
+
 // 登录后新手指引（首次进入展示，可跳过）
+// 基于网络环境探测结果，推荐最合适的使用场景
 const Onboarding: React.FC = () => {
   const navigate = useNavigate()
   const [step, setStep] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [netInfo, setNetInfo] = useState<NetworkInfo | null>(null)
 
   useEffect(() => {
     // 标记已看过引导
     try { localStorage.setItem('netpanel-onboarded', '1') } catch { /* ignore */ }
+
+    initApi.networkInfo()
+      .then((res: any) => setNetInfo(res?.data))
+      .catch(() => {})
+      .finally(() => setLoading(false))
   }, [])
 
   const finish = () => {
@@ -20,29 +45,102 @@ const Onboarding: React.FC = () => {
     navigate('/dashboard', { replace: true })
   }
 
-  const cards = [
-    {
-      icon: <CloudOutlined style={{ fontSize: 26, color: '#0071e3' }} />,
-      title: '接入公网（推荐先做）',
-      desc: '使用 CF 隧道将内网服务安全暴露到公网，无需公网 IP 与端口映射。',
-      action: () => navigate('/cftunnel', { replace: true }),
-      actionText: '开始配置 →',
-    },
-    {
+  // 根据网络环境推荐场景卡片
+  const buildCards = () => {
+    const cards: Array<{
+      icon: React.ReactNode
+      title: string
+      desc: string
+      tag?: string
+      action: () => void
+      actionText: string
+    }> = []
+
+    if (!netInfo) {
+      // 加载失败时显示默认推荐
+      cards.push({
+        icon: <CloudOutlined style={{ fontSize: 26, color: '#0071e3' }} />,
+        title: '接入公网（推荐先做）',
+        desc: '使用 CF 隧道将内网服务安全暴露到公网，无需公网 IP 与端口映射。',
+        action: () => navigate('/cftunnel', { replace: true }),
+        actionText: '开始配置 →',
+      })
+    } else {
+      // 有公网 IP：推荐端口转发 + FRP
+      if (netInfo.has_ipv4) {
+        cards.push({
+          icon: <GlobalOutlined style={{ fontSize: 26, color: '#0071e3' }} />,
+          title: '端口转发',
+          tag: '有公网 IP',
+          desc: `检测到公网 IPv4：${netInfo.public_ip_v4}。可直接配置端口转发，将内网服务映射到公网。`,
+          action: () => navigate('/port-forward', { replace: true }),
+          actionText: '配置端口转发 →',
+        })
+      }
+
+      // 无公网 IPv4：推荐 CF 隧道（免费免配置）
+      if (!netInfo.has_ipv4) {
+        cards.push({
+          icon: <CloudOutlined style={{ fontSize: 26, color: '#0071e3' }} />,
+          title: 'CF 隧道（免公网 IP）',
+          tag: '推荐',
+          desc: '未检测到公网 IPv4，推荐使用 Cloudflare Tunnel，免费将内网服务安全暴露到公网。',
+          action: () => navigate('/cftunnel', { replace: true }),
+          actionText: '配置 CF 隧道 →',
+        })
+      }
+
+      // 有 TUN：推荐组网
+      if (netInfo.tun_capable) {
+        cards.push({
+          icon: <ApiOutlined style={{ fontSize: 26, color: '#5e5ce6' }} />,
+          title: '异地组网',
+          tag: 'TUN 可用',
+          desc: 'TUN 设备可用，可使用 EasyTier 或 WireGuard 将多台设备组成虚拟局域网。',
+          action: () => navigate('/easytier/client', { replace: true }),
+          actionText: '配置组网 →',
+        })
+      } else {
+        cards.push({
+          icon: <ToolOutlined style={{ fontSize: 26, color: '#ff9500' }} />,
+          title: '异地组网（需配置）',
+          tag: 'TUN 不可用',
+          desc: '当前环境不支持 TUN 设备（Docker 需添加 --device /dev/net/tun），组网功能暂不可用。',
+          action: () => navigate('/help', { replace: true }),
+          actionText: '查看部署说明 →',
+        })
+      }
+    }
+
+    // 通用卡片
+    cards.push({
       icon: <SafetyOutlined style={{ fontSize: 26, color: '#34c759' }} />,
       title: '开启安全防护',
       desc: '启用 WAF 安全中心，自动拦截 SQL 注入、暴力破解等攻击，自动封禁恶意 IP。',
       action: () => navigate('/security/waf', { replace: true }),
       actionText: '立即开启 →',
-    },
-    {
+    })
+
+    cards.push({
       icon: <QuestionCircleOutlined style={{ fontSize: 26, color: '#bf5af2' }} />,
       title: '查看使用说明',
       desc: '每个功能页都内置说明文档与常见问题，随时可在「帮助与说明」查阅。',
       action: () => navigate('/help', { replace: true }),
       actionText: '查看帮助 →',
-    },
-  ]
+    })
+
+    return cards
+  }
+
+  if (loading) {
+    return (
+      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Spin size="large" tip="正在检测网络环境..." />
+      </div>
+    )
+  }
+
+  const cards = buildCards()
 
   return (
     <div style={{
@@ -57,7 +155,11 @@ const Onboarding: React.FC = () => {
             display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 28, color: '#fff', fontWeight: 700,
           }}>N</div>
           <Title level={3} style={{ marginBottom: 4 }}>欢迎使用 NetPanel</Title>
-          <Text type="secondary">已就绪 · 花 30 秒完成基础配置</Text>
+          <Text type="secondary">
+            {netInfo?.has_ipv4
+              ? `已检测到公网 IP · ${netInfo.public_ip_v4}`
+              : '正在为你推荐最佳使用方式'}
+          </Text>
           <div style={{ maxWidth: 320, margin: '20px auto 0' }}>
             <Steps size="small" current={step} items={[{ title: '入门' }, { title: '进阶' }, { title: '完成' }]} />
           </div>
@@ -67,8 +169,11 @@ const Onboarding: React.FC = () => {
           {cards.map((c, i) => (
             <Col xs={24} md={8} key={c.title}>
               <Card hoverable size="small" style={{ borderRadius: 'var(--radius-md)', height: '100%' }}
-                onClick={() => { setStep(i + 1); c.action() }}>
-                <div style={{ marginBottom: 12 }}>{c.icon}</div>
+                onClick={() => { setStep(Math.min(i + 1, 2)); c.action() }}>
+                <div style={{ marginBottom: 12 }}>
+                  {c.icon}
+                  {c.tag && <Tag color={c.tag === '推荐' ? 'blue' : c.tag.includes('不可用') ? 'orange' : 'green'} style={{ marginLeft: 8, fontSize: 11 }}>{c.tag}</Tag>}
+                </div>
                 <b>{c.title}</b>
                 <Paragraph type="secondary" style={{ fontSize: 12.5, marginTop: 8, marginBottom: 10 }}>{c.desc}</Paragraph>
                 <span style={{ color: '#0071e3', fontSize: 13, fontWeight: 600 }}>{c.actionText}</span>


### PR DESCRIPTION
## 变更概要

### 1. Docker 简化部署
- 新增 `docker-compose.minimal.yml`：最小化部署，仅端口映射 + 数据卷，无需 NET_ADMIN / TUN / sysctl，适合只需 Web 面板和基础功能的场景
- 新增 `docker-compose.full.yml`：完整部署，含 TUN 设备和组网能力
- 原 `docker-compose.yml` 顶部加版本选择引导注释

### 2. 首次运行向导
- 新增后端 API `GET /api/v1/init/network-info`，并发探测公网 IPv4/IPv6 和 TUN 设备可用性
- 重写 Onboarding 页面，基于网络环境给出场景化推荐：
  - 有公网 IP → 推荐端口转发
  - 无公网 IPv4 → 推荐 CF 隧道（标记推荐）
  - TUN 可用 → 推荐异地组网
  - TUN 不可用 → 提示部署配置问题

### 3. 国内镜像加速
- install.sh 和 install.ps1 新增 `NETPANEL_MIRROR` 环境变量支持
- 默认 auto 模式：先直连 GitHub，失败后自动回退 ghproxy → fastgit
- 可强制指定 `ghproxy` / `fastgit` / `direct`

### 4. 文档同步
- README Docker 部分重写为 minimal / full 两种选择
- 文档站点 installation.md 同步更新，修正仓库地址